### PR TITLE
[FIX] go-redis error on startup

### DIFF
--- a/api/init.go
+++ b/api/init.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-co-op/gocron/v2"
 	"github.com/redis/go-redis/v9"
 	"gorm.io/driver/mysql"
+	"github.com/redis/go-redis/v9/maintnotifications"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/driver/sqlserver"
@@ -118,6 +119,9 @@ func openRedis(cfg config.RedisConfig) (*redis.Client, error) {
 		Addr:     addr,
 		Password: cfg.Password,
 		DB:       0,
+		MaintNotificationsConfig: &maintnotifications.Config{
+			Mode: maintnotifications.ModeDisabled,
+		},
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()


### PR DESCRIPTION
Fix `redis: 2026/01/14 08:50:42 redis.go:478: auto mode fallback: maintnotifications disabled due to handshake error: ERR unknown subcommand 'maint_notifications'. Try CLIENT HELP.` error on startup.

This is a upstream issue, reference https://github.com/redis/go-redis/issues/3536#issuecomment-3499924405