### PR TITLE
[Feat] Replace git2 with git CLI and add commit signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,21 +1284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git2"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
-dependencies = [
- "bitflags 2.10.0",
- "libc",
- "libgit2-sys",
- "log",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "url",
-]
-
-[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,7 +1325,6 @@ dependencies = [
  "cbc",
  "chrono",
  "futures",
- "git2",
  "hex",
  "indexmap",
  "jsonwebtoken",
@@ -1943,20 +1927,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.18.3+1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
-dependencies = [
- "cc",
- "libc",
- "libssh2-sys",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,36 +1955,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "libyaml-rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
-
-[[package]]
-name = "libz-sys"
-version = "1.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "litemap"
@@ -2300,37 +2244,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
-
-[[package]]
-name = "openssl-src"
-version = "300.5.5+3.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -3093,7 +3009,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.0",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ regex = "1.12.3"
 chrono = "0.4.44"
 num_enum = "0.7.5"
 notify = "8.2.0"
-git2 = { version = "0.20.4", features = ["vendored-openssl"] }
 
 [profile.release]
 lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1.95-alpine AS builder
-RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static cmake make perl
+RUN apk add --no-cache musl-dev
 WORKDIR /app
 COPY . .
 ARG VERSION=dev
@@ -11,7 +11,7 @@ RUN if [ "$VERSION" != "dev" ]; then \
 RUN cargo build --release
 
 FROM alpine:3.23
-RUN apk --no-cache add ca-certificates tzdata
+RUN apk --no-cache add ca-certificates tzdata git gnupg openssh-keygen
 WORKDIR /app
 COPY --from=builder /app/target/release/haruki-sekai-api .
 COPY Data ./Data

--- a/haruki-sekai-configs.example.yaml
+++ b/haruki-sekai-configs.example.yaml
@@ -6,6 +6,10 @@ git:
   username: ""
   email: "@users.noreply.github.com"
   password: ""
+  sign_commits: false
+  signing_format: "gpg" # gpg | ssh
+  signing_key: "" # GPG key id, SSH public/private key path, or SSH public key
+  signing_program: "" # optional: gpg.program for GPG or gpg.ssh.program for SSH
 
 redis:
   enabled: true # set it to false if not using redis

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,6 +110,15 @@ pub struct DatabaseConfig {
     pub max_connections: u32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum GitSigningFormat {
+    #[default]
+    #[serde(alias = "openpgp")]
+    Gpg,
+    Ssh,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct GitConfig {
     #[serde(default)]
@@ -120,6 +129,14 @@ pub struct GitConfig {
     pub email: String,
     #[serde(default)]
     pub password: String,
+    #[serde(default)]
+    pub sign_commits: bool,
+    #[serde(default)]
+    pub signing_format: GitSigningFormat,
+    #[serde(default)]
+    pub signing_key: String,
+    #[serde(default)]
+    pub signing_program: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -214,6 +231,10 @@ impl Default for GitConfig {
             username: "".to_string(),
             email: "".to_string(),
             password: "".to_string(),
+            sign_commits: false,
+            signing_format: GitSigningFormat::default(),
+            signing_key: "".to_string(),
+            signing_program: "".to_string(),
         }
     }
 }

--- a/src/updater/git.rs
+++ b/src/updater/git.rs
@@ -1,18 +1,20 @@
+use std::fmt::Write as _;
 use std::path::Path;
+use std::process::{Command, Output};
 
-use git2::{
-    Cred, DiffOptions, ErrorCode, IndexAddOption, ProxyOptions, PushOptions, RemoteCallbacks,
-    Repository, Signature, StatusOptions,
-};
 use tracing::info;
 
-use crate::config::GitConfig;
+use crate::config::{GitConfig, GitSigningFormat};
 use crate::error::AppError;
 
 pub struct GitHelper {
     pub username: String,
     pub email: String,
     pub password: String,
+    pub sign_commits: bool,
+    pub signing_format: GitSigningFormat,
+    pub signing_key: String,
+    pub signing_program: String,
     pub proxy: Option<String>,
 }
 
@@ -22,6 +24,10 @@ impl GitHelper {
             username: config.username.clone(),
             email: config.email.clone(),
             password: config.password.clone(),
+            sign_commits: config.sign_commits,
+            signing_format: config.signing_format,
+            signing_key: config.signing_key.clone(),
+            signing_program: config.signing_program.clone(),
             proxy,
         }
     }
@@ -35,217 +41,202 @@ impl GitHelper {
             )));
         }
 
-        let repo = Repository::discover(path)
-            .map_err(|e| AppError::NetworkError(format!("Failed to open git repository: {}", e)))?;
-
-        if !self.has_changes(&repo)? {
-            if !self.has_unpushed_commits(&repo)? {
+        if !self.has_changes(repo_path)? {
+            if !self.has_unpushed_commits(repo_path)? {
                 info!("No changes to commit or push");
                 return Ok(false);
             }
             info!("Found unpushed commits");
         } else {
-            self.stage_all(&repo)?;
-
+            self.stage_all(repo_path)?;
             let commit_msg = format!("Sekai master data version {}", data_version);
-            let author = "Haruki Sekai Master Update Bot";
-            let author_email = "no-reply@mail.seiunx.com";
-            self.commit(&repo, &commit_msg, author, author_email)?;
+            self.commit(
+                repo_path,
+                &commit_msg,
+                "Haruki Sekai Master Update Bot",
+                "no-reply@mail.seiunx.com",
+            )?;
             info!("Committed changes: {}", commit_msg);
         }
 
-        self.push(&repo)?;
+        self.push(repo_path)?;
         info!("Pushed changes successfully");
         Ok(true)
     }
 
-    fn has_changes(&self, repo: &Repository) -> Result<bool, AppError> {
-        let mut opts = StatusOptions::new();
-        opts.include_untracked(true)
-            .recurse_untracked_dirs(true)
-            .include_ignored(false);
-
-        let statuses = repo
-            .statuses(Some(&mut opts))
-            .map_err(|e| AppError::NetworkError(format!("Failed to get git status: {}", e)))?;
-
-        Ok(!statuses.is_empty())
+    fn git(&self, repo_path: &str) -> Command {
+        let mut command = Command::new("git");
+        command.arg("-C").arg(repo_path);
+        command
     }
 
-    fn has_unpushed_commits(&self, repo: &Repository) -> Result<bool, AppError> {
-        let head = match repo.head() {
-            Ok(h) => h,
-            Err(e) if e.code() == ErrorCode::UnbornBranch => return Ok(false),
-            Err(e) => return Err(AppError::NetworkError(format!("Failed to get HEAD: {}", e))),
-        };
+    fn run(&self, mut command: Command, action: &str) -> Result<Output, AppError> {
+        let output = command
+            .output()
+            .map_err(|e| AppError::NetworkError(format!("Failed to run git {}: {}", action, e)))?;
 
-        let local_oid = head.target().ok_or_else(|| {
-            AppError::NetworkError("HEAD does not point to a valid commit".to_string())
-        })?;
-
-        let branch = repo
-            .find_branch(head.shorthand().unwrap_or("main"), git2::BranchType::Local)
-            .map_err(|e| AppError::NetworkError(format!("Failed to find local branch: {}", e)))?;
-
-        let upstream = match branch.upstream() {
-            Ok(u) => u,
-            Err(_) => return Ok(false),
-        };
-
-        let upstream_oid = upstream.get().target().ok_or_else(|| {
-            AppError::NetworkError("Upstream does not point to a valid commit".to_string())
-        })?;
-
-        let (ahead, _behind) = repo
-            .graph_ahead_behind(local_oid, upstream_oid)
-            .map_err(|e| AppError::NetworkError(format!("Failed to compare commits: {}", e)))?;
-
-        Ok(ahead > 0)
-    }
-
-    fn stage_all(&self, repo: &Repository) -> Result<(), AppError> {
-        let mut index = repo
-            .index()
-            .map_err(|e| AppError::NetworkError(format!("Failed to get index: {}", e)))?;
-
-        index
-            .add_all(["*"].iter(), IndexAddOption::DEFAULT, None)
-            .map_err(|e| AppError::NetworkError(format!("Failed to stage files: {}", e)))?;
-
-        // Also handle deletions: update index to remove files that no longer exist on disk
-        let mut diff_opts = DiffOptions::new();
-        let diff = repo
-            .diff_index_to_workdir(Some(&index), Some(&mut diff_opts))
-            .map_err(|e| AppError::NetworkError(format!("Failed to diff index: {}", e)))?;
-
-        let deleted_paths: Vec<String> = diff
-            .deltas()
-            .filter(|d| d.status() == git2::Delta::Deleted)
-            .filter_map(|d| d.old_file().path())
-            .map(|p| p.to_string_lossy().to_string())
-            .collect();
-
-        for path in &deleted_paths {
-            let _ = index.remove_path(Path::new(path));
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let detail = stderr.trim();
+            let detail = if detail.is_empty() {
+                output.status.to_string()
+            } else {
+                detail.to_string()
+            };
+            return Err(AppError::NetworkError(format!(
+                "git {} failed: {}",
+                action, detail
+            )));
         }
 
-        index
-            .write()
-            .map_err(|e| AppError::NetworkError(format!("Failed to write index: {}", e)))?;
+        Ok(output)
+    }
 
+    fn has_changes(&self, repo_path: &str) -> Result<bool, AppError> {
+        let mut cmd = self.git(repo_path);
+        cmd.args(["status", "--porcelain"]);
+        let output = self.run(cmd, "status")?;
+        Ok(!output.stdout.is_empty())
+    }
+
+    fn has_unpushed_commits(&self, repo_path: &str) -> Result<bool, AppError> {
+        // Errors when there's no upstream or HEAD is unborn — both mean "nothing to push".
+        let output = self
+            .git(repo_path)
+            .args(["rev-list", "--count", "@{u}..HEAD"])
+            .output()
+            .map_err(|e| AppError::NetworkError(format!("Failed to run git rev-list: {}", e)))?;
+        if !output.status.success() {
+            return Ok(false);
+        }
+        let count: u32 = String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .parse()
+            .unwrap_or(0);
+        Ok(count > 0)
+    }
+
+    fn stage_all(&self, repo_path: &str) -> Result<(), AppError> {
+        let mut cmd = self.git(repo_path);
+        cmd.args(["add", "-A"]);
+        self.run(cmd, "add")?;
         Ok(())
     }
 
     fn commit(
         &self,
-        repo: &Repository,
+        repo_path: &str,
         message: &str,
         author_name: &str,
         author_email: &str,
     ) -> Result<(), AppError> {
-        let sig_author = Signature::now(author_name, author_email).map_err(|e| {
-            AppError::NetworkError(format!("Failed to create author signature: {}", e))
-        })?;
+        let mut cmd = self.git(repo_path);
 
-        let sig_committer = Signature::now(&self.username, &self.email).map_err(|e| {
-            AppError::NetworkError(format!("Failed to create committer signature: {}", e))
-        })?;
-
-        let mut index = repo
-            .index()
-            .map_err(|e| AppError::NetworkError(format!("Failed to get index: {}", e)))?;
-
-        let tree_oid = index
-            .write_tree()
-            .map_err(|e| AppError::NetworkError(format!("Failed to write tree: {}", e)))?;
-
-        let tree = repo
-            .find_tree(tree_oid)
-            .map_err(|e| AppError::NetworkError(format!("Failed to find tree: {}", e)))?;
-
-        let parent_commit = match repo.head() {
-            Ok(head) => {
-                let oid = head
-                    .target()
-                    .ok_or_else(|| AppError::NetworkError("HEAD has no target".to_string()))?;
-                Some(repo.find_commit(oid).map_err(|e| {
-                    AppError::NetworkError(format!("Failed to find parent commit: {}", e))
-                })?)
+        if self.sign_commits {
+            let (format, program_key) = match self.signing_format {
+                GitSigningFormat::Gpg => ("openpgp", "gpg.program"),
+                GitSigningFormat::Ssh => ("ssh", "gpg.ssh.program"),
+            };
+            cmd.arg("-c").arg(format!("gpg.format={}", format));
+            if !self.signing_program.is_empty() {
+                cmd.arg("-c")
+                    .arg(format!("{}={}", program_key, self.signing_program));
             }
-            Err(e) if e.code() == ErrorCode::UnbornBranch => None,
-            Err(e) => return Err(AppError::NetworkError(format!("Failed to get HEAD: {}", e))),
+            if !self.signing_key.is_empty() {
+                cmd.arg("-c")
+                    .arg(format!("user.signingkey={}", self.signing_key));
+            }
+            cmd.arg("commit").arg("-S");
+        } else {
+            cmd.arg("commit");
+        }
+
+        cmd.arg("-m")
+            .arg(message)
+            .env("GIT_AUTHOR_NAME", author_name)
+            .env("GIT_AUTHOR_EMAIL", author_email)
+            .env("GIT_COMMITTER_NAME", &self.username)
+            .env("GIT_COMMITTER_EMAIL", &self.email);
+
+        self.run(cmd, "commit")?;
+        Ok(())
+    }
+
+    fn push(&self, repo_path: &str) -> Result<(), AppError> {
+        let head = self.run(
+            {
+                let mut c = self.git(repo_path);
+                c.args(["symbolic-ref", "--short", "HEAD"]);
+                c
+            },
+            "symbolic-ref",
+        )?;
+        let branch = String::from_utf8_lossy(&head.stdout).trim().to_string();
+
+        let push_target = if self.password.is_empty() {
+            "origin".to_string()
+        } else {
+            let remote = self.run(
+                {
+                    let mut c = self.git(repo_path);
+                    c.args(["remote", "get-url", "origin"]);
+                    c
+                },
+                "remote get-url",
+            )?;
+            let url = String::from_utf8_lossy(&remote.stdout).trim().to_string();
+            inject_credentials(&url, &self.username, &self.password)?
         };
 
-        let parents: Vec<&git2::Commit> = parent_commit.iter().collect();
+        let refspec = format!("refs/heads/{branch}:refs/heads/{branch}");
 
-        repo.commit(
-            Some("HEAD"),
-            &sig_author,
-            &sig_committer,
-            message,
-            &tree,
-            &parents,
-        )
-        .map_err(|e| AppError::NetworkError(format!("Failed to commit: {}", e)))?;
-
-        Ok(())
-    }
-
-    fn push(&self, repo: &Repository) -> Result<(), AppError> {
-        let head = repo
-            .head()
-            .map_err(|e| AppError::NetworkError(format!("Failed to get HEAD: {}", e)))?;
-
-        let branch_name = head.shorthand().unwrap_or("main");
-        let refspec = format!("refs/heads/{}:refs/heads/{}", branch_name, branch_name);
-
-        let mut remote = repo.find_remote("origin").map_err(|e| {
-            AppError::NetworkError(format!("Failed to find remote 'origin': {}", e))
-        })?;
-
-        let mut callbacks = RemoteCallbacks::new();
-
-        if !self.password.is_empty() {
-            let username = self.username.clone();
-            let password = self.password.clone();
-            callbacks.credentials(move |_url, _username_from_url, _allowed_types| {
-                Cred::userpass_plaintext(&username, &password)
-            });
-        }
-
-        // Report push errors via the callback
-        callbacks.push_update_reference(|refname, status| {
-            if let Some(msg) = status {
-                Err(git2::Error::from_str(&format!(
-                    "Failed to push ref {}: {}",
-                    refname, msg
-                )))
-            } else {
-                Ok(())
-            }
-        });
-
-        let mut push_opts = PushOptions::new();
-        push_opts.remote_callbacks(callbacks);
-
-        if let Some(ref proxy_url) = self.proxy {
-            if !proxy_url.is_empty() {
-                let mut proxy_opts = ProxyOptions::new();
-                proxy_opts.url(proxy_url);
-                push_opts.proxy_options(proxy_opts);
+        let mut cmd = self.git(repo_path);
+        if let Some(proxy) = self.proxy.as_deref() {
+            if !proxy.is_empty() {
+                cmd.arg("-c").arg(format!("http.proxy={}", proxy));
             }
         }
+        cmd.args(["push", &push_target, &refspec])
+            .env("GIT_TERMINAL_PROMPT", "0");
 
-        remote
-            .push(&[&refspec], Some(&mut push_opts))
-            .map_err(|e| {
-                let msg = e.message().to_string();
-                if msg.contains("up-to-date") {
-                    return AppError::NetworkError("Already up-to-date".to_string());
-                }
-                AppError::NetworkError(format!("Git push failed: {}", msg))
-            })?;
-
+        self.run(cmd, "push")?;
         Ok(())
     }
+}
+
+fn inject_credentials(url: &str, username: &str, password: &str) -> Result<String, AppError> {
+    let scheme_end = if let Some(rest) = url.strip_prefix("https://") {
+        ("https://", rest)
+    } else if let Some(rest) = url.strip_prefix("http://") {
+        ("http://", rest)
+    } else {
+        return Err(AppError::NetworkError(format!(
+            "Cannot inject credentials into non-HTTP(S) remote URL: {}",
+            url
+        )));
+    };
+    let (scheme, rest) = scheme_end;
+    let rest = match rest.find('@') {
+        Some(at) if !rest[..at].contains('/') => &rest[at + 1..],
+        _ => rest,
+    };
+    Ok(format!(
+        "{}{}:{}@{}",
+        scheme,
+        pct_encode(username),
+        pct_encode(password),
+        rest
+    ))
+}
+
+fn pct_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        if matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~') {
+            out.push(b as char);
+        } else {
+            let _ = write!(out, "%{:02X}", b);
+        }
+    }
+    out
 }


### PR DESCRIPTION
## Summary
- Add GPG / SSH signed commit support to the master data updater via new `git.sign_commits` / `signing_format` / `signing_key` / `signing_program` config keys
- Rewrite `src/updater/git.rs` on top of the `git` CLI, unifying the signed and unsigned paths and dropping the `git2` crate (it was only used here)
- Slim builder image (no more `openssl-dev` / `cmake` / `make` / `perl` from git2's vendored-openssl); runtime image gains `git`, `gnupg`, `openssh-keygen` so signed pushes work out of the box

## Test plan
- [ ] Unsigned commit path: `sign_commits: false` still pushes master data updates as before
- [ ] GPG signed commit: configure `signing_format: gpg` + `signing_key`, verify resulting commit has a valid GPG signature
- [ ] SSH signed commit: configure `signing_format: ssh` + `signing_key`, verify signature
- [ ] HTTPS push auth still works with username/password (creds embedded in push URL only, not persisted in remote)
- [ ] Proxy config still applied via `-c http.proxy=...`
- [ ] Docker image builds and `git`/`gpg`/`ssh-keygen` available at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)