### PR TITLE
[Fix] Deep-review hardening across API, client, and updater

### DIFF
--- a/src/api/apis.rs
+++ b/src/api/apis.rs
@@ -127,26 +127,23 @@ async fn proxy_game_api_cached(
     }
 
     // Coalesce concurrent misses for the same key onto a single upstream call;
-    // followers await and share the leader's result.
-    let (outcome, is_leader) = state
+    // followers await and share the leader's outcome (success or failure).
+    let (outcome, _is_leader) = state
         .coalescer
         .coalesce(&cache_key, || async {
             let resp = proxy_game_api(state, server, path).await?;
             let status = resp.status.as_u16();
             let json: Arc<str> =
                 Arc::from(sonic_rs::to_string(&resp.body).unwrap_or_else(|_| "{}".to_string()));
+            // Populate the cache inside the in-flight window (200 only), so
+            // requests arriving between slot release and SETEX completion still
+            // hit the cache instead of stampeding upstream.
+            if status == 200 {
+                cache_set(state, &cache_key, &json, ttl_secs).await;
+            }
             Ok((status, json))
         })
         .await;
-
-    // The leader populates the cache (200 only); followers just reuse the result.
-    if is_leader {
-        if let Ok((status, json)) = &outcome {
-            if *status == 200 {
-                cache_set(state, &cache_key, json, ttl_secs).await;
-            }
-        }
-    }
 
     let (status, json) = outcome?;
     Ok(json_string_response(

--- a/src/api/image.rs
+++ b/src/api/image.rs
@@ -25,10 +25,16 @@ fn image_error_response(context: &str, e: AppError) -> Response {
         status: status.as_u16(),
         message,
     };
-    let json = sonic_rs::to_string(&body).unwrap_or_else(|_| {
-        r#"{"result":"failed","status":500,"message":"Internal error"}"#.to_string()
-    });
-    (status, [("content-type", "application/json")], json).into_response()
+    match sonic_rs::to_string(&body) {
+        Ok(json) => (status, [("content-type", "application/json")], json).into_response(),
+        // Keep the HTTP status consistent with the fallback body's status field.
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            [("content-type", "application/json")],
+            r#"{"result":"failed","status":500,"message":"Internal error"}"#.to_string(),
+        )
+            .into_response(),
+    }
 }
 
 pub async fn get_mysekai_image(

--- a/src/api/image.rs
+++ b/src/api/image.rs
@@ -6,7 +6,18 @@ use axum::{
 use regex::Regex;
 
 use crate::config::ServerRegion;
+use crate::error::AppError;
 use crate::AppState;
+
+/// Map an upstream image-fetch error to a client response: a 404 from the game
+/// server means the image does not exist and is propagated as 404; everything
+/// else uses the error's own status mapping (upstream faults surface as 502).
+fn image_error_response(context: &str, e: AppError) -> Response {
+    if let AppError::Unknown { status: 404, .. } = e {
+        return (StatusCode::NOT_FOUND, format!("{}: not found", context)).into_response();
+    }
+    (e.status_code(), format!("{}: {}", context, e)).into_response()
+}
 
 pub async fn get_mysekai_image(
     State(state): State<std::sync::Arc<AppState>>,
@@ -51,11 +62,7 @@ pub async fn get_mysekai_image(
     };
     match image_result {
         Ok(bytes) => (StatusCode::OK, [("content-type", "image/png")], bytes).into_response(),
-        Err(e) => (
-            StatusCode::BAD_GATEWAY,
-            format!("Fetch image failed: {}", e),
-        )
-            .into_response(),
+        Err(e) => image_error_response("Fetch image failed", e),
     }
 }
 
@@ -103,11 +110,7 @@ pub async fn get_mysekai_housing_thumbnail(
         .await
     {
         Ok(bytes) => (StatusCode::OK, [("content-type", "image/png")], bytes).into_response(),
-        Err(e) => (
-            StatusCode::BAD_GATEWAY,
-            format!("Fetch MySekai housing thumbnail failed: {}", e),
-        )
-            .into_response(),
+        Err(e) => image_error_response("Fetch MySekai housing thumbnail failed", e),
     }
 }
 
@@ -152,11 +155,7 @@ pub async fn get_custom_profile_card_thumbnail(
     let combined = format!("{}/{}", param1, param2);
     match client.get_cp_custom_profile_card_thumbnail(&combined).await {
         Ok(bytes) => (StatusCode::OK, [("content-type", "image/png")], bytes).into_response(),
-        Err(e) => (
-            StatusCode::BAD_GATEWAY,
-            format!("Fetch image failed: {}", e),
-        )
-            .into_response(),
+        Err(e) => image_error_response("Fetch image failed", e),
     }
 }
 
@@ -201,10 +200,6 @@ pub async fn get_custom_music_score(
             bytes,
         )
             .into_response(),
-        Err(e) => (
-            StatusCode::BAD_GATEWAY,
-            format!("Fetch custom music score failed: {}", e),
-        )
-            .into_response(),
+        Err(e) => image_error_response("Fetch custom music score failed", e),
     }
 }

--- a/src/api/image.rs
+++ b/src/api/image.rs
@@ -12,11 +12,23 @@ use crate::AppState;
 /// Map an upstream image-fetch error to a client response: a 404 from the game
 /// server means the image does not exist and is propagated as 404; everything
 /// else uses the error's own status mapping (upstream faults surface as 502).
+/// Always emits the standard JSON error body.
 fn image_error_response(context: &str, e: AppError) -> Response {
-    if let AppError::Unknown { status: 404, .. } = e {
-        return (StatusCode::NOT_FOUND, format!("{}: not found", context)).into_response();
-    }
-    (e.status_code(), format!("{}: {}", context, e)).into_response()
+    let (status, message) = match e {
+        AppError::Unknown { status: 404, .. } => {
+            (StatusCode::NOT_FOUND, format!("{}: not found", context))
+        }
+        other => (other.status_code(), format!("{}: {}", context, other)),
+    };
+    let body = crate::error::ApiErrorResponse {
+        result: "failed",
+        status: status.as_u16(),
+        message,
+    };
+    let json = sonic_rs::to_string(&body).unwrap_or_else(|_| {
+        r#"{"result":"failed","status":500,"message":"Internal error"}"#.to_string()
+    });
+    (status, [("content-type", "application/json")], json).into_response()
 }
 
 pub async fn get_mysekai_image(

--- a/src/api/middleware.rs
+++ b/src/api/middleware.rs
@@ -41,24 +41,16 @@ pub async fn auth_middleware(
     next: Next,
 ) -> Response {
     req.extensions_mut().insert(None::<AuthUser>);
-    // Fail closed: protected routes must not silently become public when the
-    // auth dependencies are missing or misconfigured.
+    // Open mode is INTENTIONAL: a deployment that does not enable the user
+    // database (or does not configure a JWT signing key) runs without
+    // authentication, and every endpoint is deliberately public. Do not "fix"
+    // this to fail closed — auth is opted into via configuration.
     let Some(ref db) = state.db else {
-        tracing::error!("Auth middleware: database unavailable; refusing request");
-        return error_response(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "Authentication service unavailable",
-        );
+        return next.run(req).await;
     };
     let jwt_secret = match &state.jwt_secret {
         Some(s) if !s.is_empty() => s,
-        _ => {
-            tracing::error!("Auth middleware: JWT signing key not configured; refusing request");
-            return error_response(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "Authentication service unavailable",
-            );
-        }
+        _ => return next.run(req).await,
     };
     let token = match req.headers().get("x-haruki-sekai-token") {
         Some(h) => match h.to_str() {

--- a/src/api/middleware.rs
+++ b/src/api/middleware.rs
@@ -41,12 +41,24 @@ pub async fn auth_middleware(
     next: Next,
 ) -> Response {
     req.extensions_mut().insert(None::<AuthUser>);
+    // Fail closed: protected routes must not silently become public when the
+    // auth dependencies are missing or misconfigured.
     let Some(ref db) = state.db else {
-        return next.run(req).await;
+        tracing::error!("Auth middleware: database unavailable; refusing request");
+        return error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Authentication service unavailable",
+        );
     };
     let jwt_secret = match &state.jwt_secret {
         Some(s) if !s.is_empty() => s,
-        _ => return next.run(req).await,
+        _ => {
+            tracing::error!("Auth middleware: JWT signing key not configured; refusing request");
+            return error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Authentication service unavailable",
+            );
+        }
     };
     let token = match req.headers().get("x-haruki-sekai-token") {
         Some(h) => match h.to_str() {

--- a/src/api/middleware.rs
+++ b/src/api/middleware.rs
@@ -15,6 +15,11 @@ use crate::db::entity::{sekai_user, sekai_user_server};
 use crate::error::ApiErrorResponse;
 use crate::AppState;
 
+/// Auth cache TTL. Deliberately short: revocation by deleting the user or the
+/// per-server grant row does not rotate the credential (which is part of the
+/// cache key), so this TTL bounds how long a revoked user keeps access.
+const AUTH_CACHE_TTL_SECS: u64 = 300;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
     pub uid: String,
@@ -36,9 +41,9 @@ pub async fn auth_middleware(
     next: Next,
 ) -> Response {
     req.extensions_mut().insert(None::<AuthUser>);
-    if state.db.is_none() {
+    let Some(ref db) = state.db else {
         return next.run(req).await;
-    }
+    };
     let jwt_secret = match &state.jwt_secret {
         Some(s) if !s.is_empty() => s,
         _ => return next.run(req).await,
@@ -74,7 +79,9 @@ pub async fn auth_middleware(
     if let Some(ref redis) = state.redis {
         // The credential is part of the key so a rotated/revoked credential misses
         // the cache and falls through to the DB check instead of being honored for
-        // up to the TTL.
+        // up to the TTL. The TTL is kept short because row deletion (revoking a
+        // user or a server grant) does not change the credential and is only
+        // picked up when the cache entry expires.
         let cache_key = format!(
             "haruki_sekai_api:{}:{}:{}",
             claims.uid, server, claims.credential
@@ -91,67 +98,65 @@ pub async fn auth_middleware(
             }
         }
     }
-    if let Some(ref db) = state.db {
-        tracing::debug!("Checking user {} for server {}", claims.uid, server);
-        let user_result = sekai_user::Entity::find_by_id(&claims.uid).one(db).await;
-        match user_result {
-            Ok(Some(user)) => {
-                if user.credential != claims.credential {
-                    return error_response(StatusCode::UNAUTHORIZED, "Invalid credential");
-                }
-                tracing::debug!(
-                    "Checking server authorization: user={}, server={}",
-                    user.id,
-                    server
-                );
-                let server_result = sekai_user_server::Entity::find()
-                    .filter(sekai_user_server::Column::UserId.eq(&user.id))
-                    .filter(sekai_user_server::Column::Server.eq(&server))
-                    .one(db)
-                    .await;
-                match server_result {
-                    Ok(Some(_)) => {
-                        tracing::debug!("User {} authorized for server {}", user.id, server);
-                        if let Some(ref redis) = state.redis {
-                            let cache_key = format!(
-                                "haruki_sekai_api:{}:{}:{}",
-                                user.id, server, claims.credential
-                            );
-                            let mut conn: redis::aio::ConnectionManager = redis.clone();
-                            let _: Result<(), _> =
-                                redis::AsyncCommands::set_ex(&mut conn, &cache_key, "1", 43200u64)
-                                    .await;
-                        }
-                        req.extensions_mut().insert(Some(AuthUser {
-                            id: claims.uid,
-                            credential: claims.credential,
-                        }));
-                        return next.run(req).await;
-                    }
-                    Ok(None) => {
-                        tracing::warn!("User {} not authorized for server {}", user.id, server);
-                        return error_response(
-                            StatusCode::FORBIDDEN,
-                            "Not authorized for this server",
+    tracing::debug!("Checking user {} for server {}", claims.uid, server);
+    let user_result = sekai_user::Entity::find_by_id(&claims.uid).one(db).await;
+    match user_result {
+        Ok(Some(user)) => {
+            if user.credential != claims.credential {
+                return error_response(StatusCode::UNAUTHORIZED, "Invalid credential");
+            }
+            tracing::debug!(
+                "Checking server authorization: user={}, server={}",
+                user.id,
+                server
+            );
+            let server_result = sekai_user_server::Entity::find()
+                .filter(sekai_user_server::Column::UserId.eq(&user.id))
+                .filter(sekai_user_server::Column::Server.eq(&server))
+                .one(db)
+                .await;
+            match server_result {
+                Ok(Some(_)) => {
+                    tracing::debug!("User {} authorized for server {}", user.id, server);
+                    if let Some(ref redis) = state.redis {
+                        let cache_key = format!(
+                            "haruki_sekai_api:{}:{}:{}",
+                            user.id, server, claims.credential
                         );
+                        let mut conn: redis::aio::ConnectionManager = redis.clone();
+                        let _: Result<(), _> = redis::AsyncCommands::set_ex(
+                            &mut conn,
+                            &cache_key,
+                            "1",
+                            AUTH_CACHE_TTL_SECS,
+                        )
+                        .await;
                     }
-                    Err(e) => {
-                        tracing::error!("Database error checking server auth: {:?}", e);
-                        return error_response(StatusCode::INTERNAL_SERVER_ERROR, "Database error");
-                    }
+                    req.extensions_mut().insert(Some(AuthUser {
+                        id: claims.uid,
+                        credential: claims.credential,
+                    }));
+                    next.run(req).await
                 }
-            }
-            Ok(None) => {
-                tracing::warn!("User {} not found in database", claims.uid);
-                return error_response(StatusCode::UNAUTHORIZED, "User not found");
-            }
-            Err(e) => {
-                tracing::error!("Database error looking up user: {:?}", e);
-                return error_response(StatusCode::INTERNAL_SERVER_ERROR, "Database error");
+                Ok(None) => {
+                    tracing::warn!("User {} not authorized for server {}", user.id, server);
+                    error_response(StatusCode::FORBIDDEN, "Not authorized for this server")
+                }
+                Err(e) => {
+                    tracing::error!("Database error checking server auth: {:?}", e);
+                    error_response(StatusCode::INTERNAL_SERVER_ERROR, "Database error")
+                }
             }
         }
+        Ok(None) => {
+            tracing::warn!("User {} not found in database", claims.uid);
+            error_response(StatusCode::UNAUTHORIZED, "User not found")
+        }
+        Err(e) => {
+            tracing::error!("Database error looking up user: {:?}", e);
+            error_response(StatusCode::INTERNAL_SERVER_ERROR, "Database error")
+        }
     }
-    next.run(req).await
 }
 
 fn extract_server_from_path(path: &str) -> String {
@@ -160,7 +165,7 @@ fn extract_server_from_path(path: &str) -> String {
         Some(part) => part,
         None => return String::new(),
     };
-    let server = if first.eq_ignore_ascii_case("api") {
+    let server = if first.eq_ignore_ascii_case("api") || first.eq_ignore_ascii_case("image") {
         parts.next().unwrap_or_default()
     } else {
         first
@@ -198,5 +203,10 @@ mod tests {
     fn extract_server_handles_empty_or_incomplete_paths() {
         assert_eq!(extract_server_from_path("/"), "");
         assert_eq!(extract_server_from_path("/api"), "");
+    }
+
+    #[test]
+    fn extract_server_uses_segment_after_image_prefix() {
+        assert_eq!(extract_server_from_path("/image/tw/mysekai/1/2"), "tw");
     }
 }

--- a/src/api/middleware.rs
+++ b/src/api/middleware.rs
@@ -183,10 +183,16 @@ fn error_response(status: StatusCode, message: &str) -> Response {
         status: status.as_u16(),
         message: message.to_string(),
     };
-    let json = sonic_rs::to_string(&body).unwrap_or_else(|_| {
-        r#"{"result":"failed","status":500,"message":"Internal error"}"#.to_string()
-    });
-    (status, [("content-type", "application/json")], json).into_response()
+    match sonic_rs::to_string(&body) {
+        Ok(json) => (status, [("content-type", "application/json")], json).into_response(),
+        // Keep the HTTP status consistent with the fallback body's status.
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            [("content-type", "application/json")],
+            r#"{"result":"failed","status":500,"message":"Internal error"}"#.to_string(),
+        )
+            .into_response(),
+    }
 }
 
 #[cfg(test)]

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -40,10 +40,6 @@ pub fn create_router(state: Arc<MainAppState>) -> Router {
     let public_routes = Router::new()
         .route("/health", get(health_check))
         .route(
-            "/image/{server}/mysekai/{param1}/{param2}",
-            get(image::get_mysekai_image),
-        )
-        .route(
             "/image/{server}/mysekai-housing/{param1}/{param2}",
             get(image::get_mysekai_housing_thumbnail),
         )
@@ -55,6 +51,20 @@ pub fn create_router(state: Arc<MainAppState>) -> Router {
             "/image/{server}/blob/custom-music-score/full/{param1}/{param2}",
             get(image::get_custom_music_score),
         );
+
+    // The mysekai image route is authenticated: unlike the other image routes
+    // (CP-only, gated by unguessable 64-hex hashes), its Nuverse branch takes a
+    // guessable numeric user_id/index and drives an authenticated game API call
+    // with the shared bot account, so it must not be publicly reachable.
+    let authed_image_routes = Router::new()
+        .route(
+            "/image/{server}/mysekai/{param1}/{param2}",
+            get(image::get_mysekai_image),
+        )
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth_middleware,
+        ));
 
     let api_routes = Router::new()
         .route("/{server}/{user_id}/profile", get(apis::get_user_profile))
@@ -95,6 +105,7 @@ pub fn create_router(state: Arc<MainAppState>) -> Router {
 
     Router::new()
         .merge(public_routes)
+        .merge(authed_image_routes)
         .nest("/api", api_routes)
         .layer(TraceLayer::new_for_http())
         .with_state(state)

--- a/src/bin/run_ingest.rs
+++ b/src/bin/run_ingest.rs
@@ -43,7 +43,8 @@ async fn main() -> anyhow::Result<()> {
         if !server.enabled || server.master_dir.is_empty() {
             continue;
         }
-        let path = format!("{}/master", server.master_dir.trim_end_matches('/'));
+        // Same layout as the master updater: files live directly in master_dir.
+        let path = server.master_dir.trim_end_matches('/').to_string();
         println!("Ingesting {} region data from {}...", region.as_str(), path);
         // Tolerate per-region failures so one region with bad files does not abort
         // ingestion for the others; ingest_master_data now errors on any bad file.

--- a/src/client/helper.rs
+++ b/src/client/helper.rs
@@ -80,7 +80,7 @@ impl CookieHelper {
             .map_err(|e| AppError::NetworkError(e.to_string()))?;
 
         let mut last_error = None;
-        for _ in 0..4 {
+        for attempt in 0..4 {
             let result = client
                 .post(&self.url)
                 .header("Accept", "*/*")
@@ -94,8 +94,24 @@ impl CookieHelper {
             match result {
                 Ok(resp) => {
                     if resp.status().is_success() {
-                        if let Some(cookie) = resp.headers().get("set-cookie") {
-                            let cookie_str = cookie.to_str().unwrap_or("").to_string();
+                        // Collect every Set-Cookie header (multi-cookie auth like
+                        // CDN signed cookies sets several), keep only the
+                        // name=value pair of each (attributes such as Path/Expires
+                        // do not belong in a Cookie request header), and treat an
+                        // unparseable/empty result as a failure instead of caching
+                        // an empty cookie as success.
+                        let cookie_str = resp
+                            .headers()
+                            .get_all("set-cookie")
+                            .iter()
+                            .filter_map(|v| v.to_str().ok())
+                            .filter_map(|v| {
+                                let pair = v.split(';').next().unwrap_or("").trim();
+                                (!pair.is_empty()).then(|| pair.to_string())
+                            })
+                            .collect::<Vec<_>>()
+                            .join("; ");
+                        if !cookie_str.is_empty() {
                             *self.cookies.lock() = cookie_str.clone();
                             return Ok(cookie_str);
                         }
@@ -106,7 +122,9 @@ impl CookieHelper {
                     last_error = Some(AppError::NetworkError(e.to_string()));
                 }
             }
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            if attempt < 3 {
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
         }
         Err(last_error
             .unwrap_or_else(|| AppError::NetworkError("Failed to fetch cookies".to_string())))

--- a/src/client/nuverse_schema.rs
+++ b/src/client/nuverse_schema.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
 
 use indexmap::IndexMap;
@@ -54,6 +54,10 @@ struct Schema {
     /// fields, sized to `max int key + 1`. Precomputed at parse time so the
     /// array-restore hot path needs no per-record map allocation. Empty otherwise.
     int_field_index: Vec<Option<usize>>,
+    /// For records: msgpack key (string form) -> index into `fields`. Precomputed
+    /// at parse time so the object-restore path is a single by-value pass over
+    /// the source map instead of per-field lookups plus a leftover scan.
+    str_field_index: HashMap<String, usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -118,21 +122,18 @@ impl NuverseSchemaStore {
         msgpack: &[u8],
     ) -> Result<IndexMap<String, JsonValue>, AppError> {
         let raw = crate::crypto::decode_msgpack_value(msgpack)?;
-        let raw_obj = raw.as_object().ok_or_else(|| {
-            AppError::ParseError("Nuverse master payload must be an object".to_string())
-        })?;
+        let JsonValue::Object(raw_obj) = raw else {
+            return Err(AppError::ParseError(
+                "Nuverse master payload must be an object".to_string(),
+            ));
+        };
         let mut restored = IndexMap::with_capacity(raw_obj.len());
         for (key, value) in raw_obj {
-            if let Some(schema_name) = self.master.get(key) {
-                if let Some(schema) = self.schema(schema_name) {
-                    restored.insert(
-                        key.clone(),
-                        restore_master_value(schema, value, &self.registry)?,
-                    );
-                    continue;
-                }
-            }
-            restored.insert(key.clone(), value.clone());
+            let value = match self.master.get(&key).and_then(|name| self.schema(name)) {
+                Some(schema) => restore_master_value(schema, value, &self.registry)?,
+                None => value,
+            };
+            restored.insert(key, value);
         }
         Ok(restored)
     }
@@ -141,14 +142,13 @@ impl NuverseSchemaStore {
         let Some(mapping) = self.api_mapping_for_path(path) else {
             return Ok(value);
         };
-        let mut restored = if let Some(schema_name) = &mapping.schema {
-            if let Some(schema) = self.schema(schema_name) {
-                restore_json(schema, &value, &self.registry)?
-            } else {
-                value
-            }
-        } else {
-            value
+        let mut restored = match mapping
+            .schema
+            .as_ref()
+            .and_then(|schema_name| self.schema(schema_name))
+        {
+            Some(schema) => restore_json(schema, value, &self.registry)?,
+            None => value,
         };
         for field in &mapping.fields {
             if let Some(schema) = self.schema(&field.schema) {
@@ -171,13 +171,13 @@ impl NuverseSchemaStore {
 }
 
 fn restore_master_value(
-    schema: &Arc<Schema>,
-    value: &JsonValue,
+    schema: &Schema,
+    value: JsonValue,
     registry: &Registry,
 ) -> Result<JsonValue, AppError> {
-    if let Some(arr) = value.as_array() {
+    if let JsonValue::Array(arr) = value {
         return arr
-            .iter()
+            .into_iter()
             .map(|item| restore_json(schema, item, registry))
             .collect::<Result<Vec<_>, _>>()
             .map(JsonValue::Array);
@@ -239,6 +239,7 @@ impl SchemaBuilder {
                     union_of,
                     union_dispatch: Vec::new(),
                     int_field_index: Vec::new(),
+                    str_field_index: HashMap::new(),
                 }))
             }
             JsonValue::Object(obj) => self.parse_object(obj),
@@ -271,6 +272,7 @@ impl SchemaBuilder {
                     union_of: Vec::new(),
                     union_dispatch: Vec::new(),
                     int_field_index: Vec::new(),
+                    str_field_index: HashMap::new(),
                 }))
             }
             "map" => {
@@ -288,6 +290,7 @@ impl SchemaBuilder {
                     union_of: Vec::new(),
                     union_dispatch: Vec::new(),
                     int_field_index: Vec::new(),
+                    str_field_index: HashMap::new(),
                 }))
             }
             primitive => Ok(self.primitive_or_ref(primitive)),
@@ -363,6 +366,15 @@ impl SchemaBuilder {
             None => Vec::new(),
         };
 
+        let mut str_field_index = HashMap::with_capacity(fields.len());
+        for (field_idx, field) in fields.iter().enumerate() {
+            let key = match &field.key {
+                MsgpackKey::String(key) => key.clone(),
+                MsgpackKey::Int(idx) => idx.to_string(),
+            };
+            str_field_index.insert(key, field_idx);
+        }
+
         let schema = Arc::new(Schema {
             kind: SchemaKind::Record,
             name: Some(full_name.clone()),
@@ -372,6 +384,7 @@ impl SchemaBuilder {
             union_of: Vec::new(),
             union_dispatch,
             int_field_index,
+            str_field_index,
         });
         if !full_name.is_empty() {
             self.registry.insert(full_name, schema.clone());
@@ -429,6 +442,7 @@ impl SchemaBuilder {
                     union_of: Vec::new(),
                     union_dispatch: Vec::new(),
                     int_field_index: Vec::new(),
+                    str_field_index: HashMap::new(),
                 })
             }
         }
@@ -441,7 +455,7 @@ impl SchemaBuilder {
 
 fn restore_json(
     schema: &Schema,
-    value: &JsonValue,
+    value: JsonValue,
     registry: &Registry,
 ) -> Result<JsonValue, AppError> {
     let schema = resolve_schema(schema, registry);
@@ -455,7 +469,7 @@ fn restore_json(
         | SchemaKind::Bytes
         | SchemaKind::String
         | SchemaKind::Any
-        | SchemaKind::Ref => Ok(value.clone()),
+        | SchemaKind::Ref => Ok(value),
         SchemaKind::Array => restore_array(schema, value, registry),
         SchemaKind::Map => restore_map(schema, value, registry),
         SchemaKind::Union => restore_union(schema, value, registry),
@@ -465,63 +479,71 @@ fn restore_json(
 
 fn restore_record(
     schema: &Schema,
-    value: &JsonValue,
+    value: JsonValue,
     registry: &Registry,
 ) -> Result<JsonValue, AppError> {
     if !schema.union_dispatch.is_empty() {
         return restore_union_dispatch(schema, value, registry);
     }
-    if let Some(arr) = value.as_array() {
-        let mut out = JsonMap::new();
-        for (idx, item) in arr.iter().enumerate() {
-            if item.is_null() {
-                continue;
-            }
-            if let Some(Some(field_idx)) = schema.int_field_index.get(idx) {
-                let field = &schema.fields[*field_idx];
-                out.insert(field.name.clone(), restore_json(&field.ty, item, registry)?);
-            }
-        }
-        return Ok(JsonValue::Object(out));
-    }
-    if let Some(obj) = value.as_object() {
-        let mut out = JsonMap::new();
-        let mut consumed = HashSet::new();
-        for field in &schema.fields {
-            let key = match &field.key {
-                MsgpackKey::String(key) => key.clone(),
-                MsgpackKey::Int(idx) => idx.to_string(),
-            };
-            let item = obj.get(&key);
-            if let Some(item) = item {
-                consumed.insert(key);
-                if !item.is_null() {
+    match value {
+        JsonValue::Array(arr) => {
+            let mut out = JsonMap::new();
+            for (idx, item) in arr.into_iter().enumerate() {
+                if item.is_null() {
+                    continue;
+                }
+                if let Some(Some(field_idx)) = schema.int_field_index.get(idx) {
+                    let field = &schema.fields[*field_idx];
                     out.insert(field.name.clone(), restore_json(&field.ty, item, registry)?);
                 }
             }
+            Ok(JsonValue::Object(out))
         }
-        for (key, item) in obj {
-            if !consumed.contains(key) {
-                out.insert(key.clone(), item.clone());
+        JsonValue::Object(obj) => {
+            // Single by-value pass: schema fields are emitted first (in schema
+            // order, matching the previous per-field lookup), then unknown keys
+            // in their original order.
+            let mut restored_fields: Vec<Option<JsonValue>> = vec![None; schema.fields.len()];
+            let mut leftovers: Vec<(String, JsonValue)> = Vec::new();
+            for (key, item) in obj {
+                match schema.str_field_index.get(&key) {
+                    Some(&field_idx) => {
+                        if !item.is_null() {
+                            let field = &schema.fields[field_idx];
+                            restored_fields[field_idx] =
+                                Some(restore_json(&field.ty, item, registry)?);
+                        }
+                    }
+                    None => leftovers.push((key, item)),
+                }
             }
+            let mut out = JsonMap::new();
+            for (field_idx, restored) in restored_fields.into_iter().enumerate() {
+                if let Some(restored) = restored {
+                    out.insert(schema.fields[field_idx].name.clone(), restored);
+                }
+            }
+            for (key, item) in leftovers {
+                out.insert(key, item);
+            }
+            Ok(JsonValue::Object(out))
         }
-        return Ok(JsonValue::Object(out));
+        other => Ok(other),
     }
-    Ok(value.clone())
 }
 
 fn restore_array(
     schema: &Schema,
-    value: &JsonValue,
+    value: JsonValue,
     registry: &Registry,
 ) -> Result<JsonValue, AppError> {
     let Some(items) = &schema.items else {
-        return Ok(value.clone());
+        return Ok(value);
     };
-    let Some(arr) = value.as_array() else {
-        return Ok(value.clone());
+    let JsonValue::Array(arr) = value else {
+        return Ok(value);
     };
-    arr.iter()
+    arr.into_iter()
         .map(|item| restore_json(items, item, registry))
         .collect::<Result<Vec<_>, _>>()
         .map(JsonValue::Array)
@@ -529,25 +551,25 @@ fn restore_array(
 
 fn restore_map(
     schema: &Schema,
-    value: &JsonValue,
+    value: JsonValue,
     registry: &Registry,
 ) -> Result<JsonValue, AppError> {
     let Some(values) = &schema.values else {
-        return Ok(value.clone());
+        return Ok(value);
     };
-    let Some(obj) = value.as_object() else {
-        return Ok(value.clone());
+    let JsonValue::Object(obj) = value else {
+        return Ok(value);
     };
     let mut out = JsonMap::new();
     for (key, item) in obj {
-        out.insert(key.clone(), restore_json(values, item, registry)?);
+        out.insert(key, restore_json(values, item, registry)?);
     }
     Ok(JsonValue::Object(out))
 }
 
 fn restore_union(
     schema: &Schema,
-    value: &JsonValue,
+    value: JsonValue,
     registry: &Registry,
 ) -> Result<JsonValue, AppError> {
     if value.is_null() {
@@ -559,32 +581,35 @@ fn restore_union(
         .map(|s| resolve_schema(s, registry))
         .find(|s| !matches!(s.kind, SchemaKind::Null))
     else {
-        return Ok(value.clone());
+        return Ok(value);
     };
     restore_json(variant, value, registry)
 }
 
 fn restore_union_dispatch(
     schema: &Schema,
-    value: &JsonValue,
+    value: JsonValue,
     registry: &Registry,
 ) -> Result<JsonValue, AppError> {
-    let Some(arr) = value.as_array() else {
-        return Ok(value.clone());
+    let mut arr = match value {
+        JsonValue::Array(arr) if arr.len() == 2 => arr,
+        other => return Ok(other),
     };
-    if arr.len() != 2 {
-        return Ok(value.clone());
-    }
-    let discriminator = arr[0].as_i64().unwrap_or_default();
+    let payload_raw = arr.pop().expect("len checked == 2");
+    let discriminator = arr
+        .pop()
+        .expect("len checked == 2")
+        .as_i64()
+        .unwrap_or_default();
     let variant = schema
         .union_dispatch
         .iter()
         .find(|variant| variant.key == discriminator)
         .and_then(|variant| registry.get(&variant.ty));
     let payload = if let Some(variant) = variant {
-        restore_json(variant, &arr[1], registry)?
+        restore_json(variant, payload_raw, registry)?
     } else {
-        arr[1].clone()
+        payload_raw
     };
     Ok(serde_json::json!({
         "__type": discriminator,
@@ -612,7 +637,7 @@ fn restore_selector_segments(
     registry: &Registry,
 ) -> Result<(), AppError> {
     let Some((segment, rest)) = segments.split_first() else {
-        *value = restore_json(schema, value, registry)?;
+        *value = restore_json(schema, std::mem::take(value), registry)?;
         return Ok(());
     };
     let (field_name, iter_array) = segment
@@ -672,6 +697,7 @@ fn leaf_schema(kind: SchemaKind) -> Schema {
         union_of: Vec::new(),
         union_dispatch: Vec::new(),
         int_field_index: Vec::new(),
+        str_field_index: HashMap::new(),
     }
 }
 
@@ -718,7 +744,7 @@ mod tests {
         let store = bundle(vec![schema], HashMap::new());
         let value = json!([1001, 2, 1711000000_i64]);
         let restored =
-            restore_json(store.schema("UserHonor").unwrap(), &value, &store.registry).unwrap();
+            restore_json(store.schema("UserHonor").unwrap(), value, &store.registry).unwrap();
         assert_eq!(restored["honorId"], json!(1001));
         assert_eq!(restored["level"], json!(2));
         assert_eq!(restored["obtainedAt"], json!(1711000000_i64));
@@ -746,8 +772,7 @@ mod tests {
         });
         let store = bundle(vec![schema], HashMap::new());
         let value = json!([1, [[100, 10], [200, 20]]]);
-        let restored =
-            restore_json(store.schema("Card").unwrap(), &value, &store.registry).unwrap();
+        let restored = restore_json(store.schema("Card").unwrap(), value, &store.registry).unwrap();
         assert_eq!(restored["costs"][0]["resourceId"], json!(100));
         assert_eq!(restored["costs"][1]["quantity"], json!(20));
     }
@@ -761,7 +786,7 @@ mod tests {
         let store = bundle(vec![schemas], HashMap::new());
         let value = json!([0, [42]]);
         let restored =
-            restore_json(store.schema("UnionBase").unwrap(), &value, &store.registry).unwrap();
+            restore_json(store.schema("UnionBase").unwrap(), value, &store.registry).unwrap();
         assert_eq!(restored["__type"], json!(0));
         assert_eq!(restored["value"]["x"], json!(42));
     }
@@ -816,7 +841,7 @@ mod tests {
         let store = bundle(vec![schema], HashMap::new());
         let value = json!({"Id": 1, "ExchangeCategory": "normal", "unknownPascal": true});
         let restored =
-            restore_json(store.schema("Summary").unwrap(), &value, &store.registry).unwrap();
+            restore_json(store.schema("Summary").unwrap(), value, &store.registry).unwrap();
         assert_eq!(restored["id"], json!(1));
         assert_eq!(restored["exchangeCategory"], json!("normal"));
         assert!(restored.get("Id").is_none());

--- a/src/client/sekai_client.rs
+++ b/src/client/sekai_client.rs
@@ -41,16 +41,6 @@ pub struct SekaiClient {
     cookie_lock: tokio::sync::Mutex<()>,
 }
 
-/// Truncate a token for logging without risking a panic on a non-ASCII byte
-/// boundary (`&s[..40]` panics if byte 40 is mid-character).
-fn token_preview(s: &str) -> &str {
-    let mut end = s.len().min(40);
-    while !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    &s[..end]
-}
-
 impl SekaiClient {
     /// Build the shared reqwest client. Every region uses identical settings (only
     /// the global proxy varies), so one client is built once in init_app_state and
@@ -205,8 +195,19 @@ impl SekaiClient {
     pub async fn reload_accounts(&self) -> Result<(), AppError> {
         let region = self.region.as_str().to_uppercase();
         info!("{} Reloading accounts...", region);
-        let accounts = self.parse_accounts()?;
+        let (accounts, json_file_count) = self.parse_accounts()?;
         if accounts.is_empty() {
+            if json_file_count > 0 {
+                // Account files exist but none parsed — likely a transient state
+                // (mid-upload, bad deploy). Keep serving with the existing pool
+                // instead of swapping in an empty one.
+                let existing = self.sessions.read().len();
+                error!(
+                    "{} All {} account file(s) in {} failed to parse; keeping {} existing session(s)",
+                    region, json_file_count, self.config.account_dir, existing
+                );
+                return Ok(());
+            }
             warn!(
                 "{} No accounts found in {}",
                 region, self.config.account_dir
@@ -331,11 +332,15 @@ impl SekaiClient {
         Ok(())
     }
 
-    fn parse_accounts(&self) -> Result<Vec<AccountType>, AppError> {
+    /// Parse every account JSON file in the account directory. Returns the
+    /// parsed accounts and the number of `.json` files seen, so callers can
+    /// distinguish "directory is empty" from "every file failed to parse".
+    fn parse_accounts(&self) -> Result<(Vec<AccountType>, usize), AppError> {
         let mut accounts = Vec::new();
+        let mut json_file_count = 0usize;
         let account_dir = Path::new(&self.config.account_dir);
         if !account_dir.exists() {
-            return Ok(accounts);
+            return Ok((accounts, json_file_count));
         }
         let entries = fs::read_dir(account_dir)
             .map_err(|e| AppError::ParseError(format!("Failed to read account dir: {}", e)))?;
@@ -344,6 +349,7 @@ impl SekaiClient {
             if path.extension().and_then(|e| e.to_str()) != Some("json") {
                 continue;
             }
+            json_file_count += 1;
             let data = match fs::read(&path) {
                 Ok(d) => d,
                 Err(e) => {
@@ -358,7 +364,7 @@ impl SekaiClient {
                 }
             }
         }
-        Ok(accounts)
+        Ok((accounts, json_file_count))
     }
 
     fn parse_account_file(&self, path: &Path, data: &[u8]) -> Result<Vec<AccountType>, AppError> {
@@ -493,11 +499,11 @@ impl SekaiClient {
             if let Ok(token_str) = token.to_str() {
                 let old_token = session.get_session_token();
                 session.set_session_token(Some(token_str.to_string()));
+                // Log only rotation metadata — never token contents.
                 debug!(
-                    "Account #{} session token updated (old: {:?}, new: {}...)",
+                    "Account #{} session token updated (had_previous: {})",
                     session.user_id(),
-                    old_token.as_deref().map(token_preview),
-                    token_preview(token_str)
+                    old_token.is_some()
                 );
             }
         }

--- a/src/client/sekai_client.rs
+++ b/src/client/sekai_client.rs
@@ -344,7 +344,13 @@ impl SekaiClient {
         }
         let entries = fs::read_dir(account_dir)
             .map_err(|e| AppError::ParseError(format!("Failed to read account dir: {}", e)))?;
-        for entry in entries.flatten() {
+        // Propagate entry errors instead of flattening them away: a transiently
+        // unreadable directory must abort the reload, not read as "no accounts"
+        // (which would clear the live session pool).
+        for entry in entries {
+            let entry = entry.map_err(|e| {
+                AppError::ParseError(format!("Failed to read account entry: {}", e))
+            })?;
             let path = entry.path();
             if path.extension().and_then(|e| e.to_str()) != Some("json") {
                 continue;
@@ -501,7 +507,8 @@ impl SekaiClient {
                 session.set_session_token(Some(token_str.to_string()));
                 // Log only rotation metadata — never token contents.
                 debug!(
-                    "Account #{} session token updated (had_previous: {})",
+                    "{} Account #{} session token updated (had_previous: {})",
+                    self.region.as_str().to_uppercase(),
                     session.user_id(),
                     old_token.is_some()
                 );
@@ -562,15 +569,18 @@ impl SekaiClient {
                 Err(e) => {
                     if e.is_timeout() {
                         warn!(
-                            "Account #{} request timed out (attempt {}/{})",
-                            user_id, attempt, max_attempts
+                            "{} Account #{} request timed out (attempt {}/{})",
+                            self.region.as_str().to_uppercase(),
+                            user_id,
+                            attempt,
+                            max_attempts
                         );
                     } else {
                         error!(
-                            "request error (attempt {}/{}): server={}, err={}",
+                            "{} Request error (attempt {}/{}): {}",
+                            self.region.as_str().to_uppercase(),
                             attempt,
                             max_attempts,
-                            self.region.as_str().to_uppercase(),
                             e
                         );
                     }

--- a/src/client/sekai_client.rs
+++ b/src/client/sekai_client.rs
@@ -36,6 +36,19 @@ pub struct SekaiClient {
 
     sessions: Arc<RwLock<Vec<Arc<AccountSession>>>>,
     session_index: AtomicUsize,
+    /// Serializes cookie refresh (client-wide state) so concurrent requests that
+    /// all observe expired cookies do not each hit the cookie service.
+    cookie_lock: tokio::sync::Mutex<()>,
+}
+
+/// Truncate a token for logging without risking a panic on a non-ASCII byte
+/// boundary (`&s[..40]` panics if byte 40 is mid-character).
+fn token_preview(s: &str) -> &str {
+    let mut end = s.len().min(40);
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
 }
 
 impl SekaiClient {
@@ -108,6 +121,7 @@ impl SekaiClient {
             http_client,
             sessions: Arc::new(RwLock::new(Vec::new())),
             session_index: AtomicUsize::new(0),
+            cookie_lock: tokio::sync::Mutex::new(()),
         };
         Ok(client)
     }
@@ -147,43 +161,7 @@ impl SekaiClient {
         }
         let version = self.version_helper.load().await?;
         self.update_version_headers(&version);
-        let accounts = self.parse_accounts()?;
-        if accounts.is_empty() {
-            warn!(
-                "{} No accounts found in {}",
-                self.region.as_str().to_uppercase(),
-                self.config.account_dir
-            );
-            return Ok(());
-        }
-        for account in accounts {
-            if self.region.is_cp_server() && account.user_id().is_empty() {
-                warn!(
-                    "{} Skipping account with empty user_id",
-                    self.region.as_str().to_uppercase()
-                );
-                continue;
-            }
-            let session = Arc::new(AccountSession::new(account));
-            match self.login(&session).await {
-                Ok(_) => {
-                    self.sessions.write().push(session);
-                }
-                Err(e) => {
-                    error!(
-                        "{} Failed to login account: {}",
-                        self.region.as_str().to_uppercase(),
-                        e
-                    );
-                }
-            }
-        }
-        info!(
-            "{} Client initialized with {} sessions",
-            self.region.as_str().to_uppercase(),
-            self.sessions.read().len()
-        );
-        Ok(())
+        self.reload_accounts().await
     }
 
     fn update_version_headers(&self, version: &VersionInfo) {
@@ -228,6 +206,12 @@ impl SekaiClient {
         let region = self.region.as_str().to_uppercase();
         info!("{} Reloading accounts...", region);
         let accounts = self.parse_accounts()?;
+        if accounts.is_empty() {
+            warn!(
+                "{} No accounts found in {}",
+                region, self.config.account_dir
+            );
+        }
 
         // Log every account in concurrently, building the new session set off to
         // the side. The existing sessions keep serving traffic the whole time, so
@@ -512,8 +496,8 @@ impl SekaiClient {
                 debug!(
                     "Account #{} session token updated (old: {:?}, new: {}...)",
                     session.user_id(),
-                    old_token.as_deref().map(|s| &s[..s.len().min(40)]),
-                    &token_str[..token_str.len().min(40)]
+                    old_token.as_deref().map(token_preview),
+                    token_preview(token_str)
                 );
             }
         }
@@ -522,7 +506,7 @@ impl SekaiClient {
     pub async fn call_api<T: serde::Serialize>(
         &self,
         session: &AccountSession,
-        method: &str,
+        method: reqwest::Method,
         path: &str,
         data: Option<&T>,
         params: Option<&HashMap<String, String>>,
@@ -534,37 +518,35 @@ impl SekaiClient {
     async fn call_api_with_timeout<T: serde::Serialize>(
         &self,
         session: &AccountSession,
-        method: &str,
+        method: reqwest::Method,
         path: &str,
         data: Option<&T>,
         params: Option<&HashMap<String, String>>,
         request_timeout: Option<Duration>,
     ) -> Result<Response, AppError> {
         let _lock = session.lock_api().await;
-        let user_id = session.user_id().to_string();
+        let user_id = session.user_id();
         let url = format!("{}/api{}", self.config.api_url, path).replace("{userId}", &user_id);
-        info!("Account #{} {} {}", user_id, method.to_uppercase(), path);
-        let max_retries = 4;
+        info!("Account #{} {} {}", user_id, method, path);
+        // Only idempotent requests are retried at the network layer: a timed-out
+        // POST/PUT may already have been executed server-side, so resending it
+        // risks double-executing the game action.
+        let max_attempts = if method == reqwest::Method::GET { 2 } else { 1 };
+        let packed = match data {
+            Some(body_data) => Some(self.cryptor.pack(body_data)?),
+            None => None,
+        };
         let mut last_error = None;
-        for attempt in 1..=max_retries {
-            let method_enum = match method.to_uppercase().as_str() {
-                "GET" => reqwest::Method::GET,
-                "POST" => reqwest::Method::POST,
-                "PUT" => reqwest::Method::PUT,
-                "DELETE" => reqwest::Method::DELETE,
-                "PATCH" => reqwest::Method::PATCH,
-                _ => reqwest::Method::GET,
-            };
-            let mut req = self.prepare_request(session, method_enum, &url);
+        for attempt in 1..=max_attempts {
+            let mut req = self.prepare_request(session, method.clone(), &url);
             if let Some(timeout) = request_timeout {
                 req = req.timeout(timeout);
             }
             if let Some(p) = params {
                 req = req.query(p);
             }
-            if let Some(body_data) = data {
-                let packed = self.cryptor.pack(body_data)?;
-                req = req.body(packed);
+            if let Some(body) = &packed {
+                req = req.body(body.clone());
             }
             match req.send().await {
                 Ok(resp) => {
@@ -574,14 +556,14 @@ impl SekaiClient {
                 Err(e) => {
                     if e.is_timeout() {
                         warn!(
-                            "Account #{} request timed out (attempt {}), retrying...",
-                            session.user_id(),
-                            attempt
+                            "Account #{} request timed out (attempt {}/{})",
+                            user_id, attempt, max_attempts
                         );
                     } else {
                         error!(
-                            "request error (attempt {}): server={}, err={}",
+                            "request error (attempt {}/{}): server={}, err={}",
                             attempt,
+                            max_attempts,
                             self.region.as_str().to_uppercase(),
                             e
                         );
@@ -589,7 +571,7 @@ impl SekaiClient {
                     last_error = Some(AppError::NetworkError(e.to_string()));
                 }
             }
-            if attempt < max_retries {
+            if attempt < max_attempts {
                 tokio::time::sleep(Duration::from_secs(1)).await;
             }
         }
@@ -604,7 +586,7 @@ impl SekaiClient {
         path: &str,
         params: Option<&HashMap<String, String>>,
     ) -> Result<Response, AppError> {
-        self.call_api::<()>(session, "GET", path, None, params)
+        self.call_api::<()>(session, reqwest::Method::GET, path, None, params)
             .await
     }
 
@@ -615,8 +597,15 @@ impl SekaiClient {
         params: Option<&HashMap<String, String>>,
         timeout: Duration,
     ) -> Result<Response, AppError> {
-        self.call_api_with_timeout::<()>(session, "GET", path, None, params, Some(timeout))
-            .await
+        self.call_api_with_timeout::<()>(
+            session,
+            reqwest::Method::GET,
+            path,
+            None,
+            params,
+            Some(timeout),
+        )
+        .await
     }
 
     pub async fn post<T: serde::Serialize>(
@@ -626,7 +615,8 @@ impl SekaiClient {
         data: Option<&T>,
         params: Option<&HashMap<String, String>>,
     ) -> Result<Response, AppError> {
-        self.call_api(session, "POST", path, data, params).await
+        self.call_api(session, reqwest::Method::POST, path, data, params)
+            .await
     }
 
     /// Read an octet-stream game response: classify the Sekai HTTP status, then
@@ -772,7 +762,7 @@ impl SekaiClient {
         params: Option<&HashMap<String, String>>,
     ) -> Result<(JsonValue, u16), AppError> {
         let session = self.get_session().ok_or(AppError::NoClientAvailable)?;
-        self.drive_game_api::<()>(&session, "GET", path, None, params, true)
+        self.drive_game_api::<()>(&session, reqwest::Method::GET, path, None, params, true)
             .await
     }
 
@@ -783,7 +773,7 @@ impl SekaiClient {
     async fn drive_game_api<T: serde::Serialize>(
         &self,
         session: &AccountSession,
-        method: &str,
+        method: reqwest::Method,
         path: &str,
         body: Option<&T>,
         params: Option<&HashMap<String, String>>,
@@ -792,7 +782,9 @@ impl SekaiClient {
         let max_retries = 4;
         let mut retry_count = 0;
         while retry_count < max_retries {
-            let resp = self.call_api(session, method, path, body, params).await?;
+            let resp = self
+                .call_api(session, method.clone(), path, body, params)
+                .await?;
             match self.handle_response_value(resp).await {
                 Ok((mut json_value, upstream_status)) => {
                     if restore && !self.region.is_cp_server() {
@@ -830,7 +822,15 @@ impl SekaiClient {
                             "{} Cookies expired, refreshing...",
                             self.region.as_str().to_uppercase()
                         );
-                        self.refresh_cookies().await?;
+                        // Single-flight: cookies are client-wide state, so only the
+                        // first caller refreshes; the rest wait on cookie_lock and
+                        // skip the refresh once they see the cookie already changed.
+                        let cookie_before = self.headers.lock().get("Cookie").cloned();
+                        let guard = self.cookie_lock.lock().await;
+                        if self.headers.lock().get("Cookie").cloned() == cookie_before {
+                            self.refresh_cookies().await?;
+                        }
+                        drop(guard);
                         retry_count += 1;
                         tokio::time::sleep(Duration::from_secs(1)).await;
                     } else {
@@ -842,42 +842,50 @@ impl SekaiClient {
                         "{} Server upgrade required, refreshing version and re-logging in...",
                         self.region.as_str().to_uppercase()
                     );
-                    // First attempt: refresh version from file and try login
-                    self.refresh_version().await?;
-                    match self.login(session).await {
-                        Ok(login_resp) => {
-                            self.update_version_headers_from_login(&login_resp);
-                        }
-                        Err(AppError::UpgradeRequired) => {
-                            warn!(
-                                "{} Login returned 426, waiting for app version update...",
-                                self.region.as_str().to_uppercase()
-                            );
-                            tokio::time::sleep(Duration::from_secs(10)).await;
-                            self.refresh_version().await?;
-                            match self.login(session).await {
-                                Ok(login_resp) => {
-                                    self.update_version_headers_from_login(&login_resp);
-                                }
-                                Err(e) => {
-                                    error!(
-                                        "{} Re-login after waiting for app update failed: {}",
-                                        self.region.as_str().to_uppercase(),
-                                        e
-                                    );
-                                    return Err(AppError::UpgradeRequired);
+                    // Single-flight per account, same pattern as SessionError: the
+                    // first caller refreshes version headers and re-logs-in; waiters
+                    // see the rotated token and go straight to the retry.
+                    let token_before = session.get_session_token();
+                    let guard = session.lock_login().await;
+                    if session.get_session_token() == token_before {
+                        // First attempt: refresh version from file and try login
+                        self.refresh_version().await?;
+                        match self.login(session).await {
+                            Ok(login_resp) => {
+                                self.update_version_headers_from_login(&login_resp);
+                            }
+                            Err(AppError::UpgradeRequired) => {
+                                warn!(
+                                    "{} Login returned 426, waiting for app version update...",
+                                    self.region.as_str().to_uppercase()
+                                );
+                                tokio::time::sleep(Duration::from_secs(10)).await;
+                                self.refresh_version().await?;
+                                match self.login(session).await {
+                                    Ok(login_resp) => {
+                                        self.update_version_headers_from_login(&login_resp);
+                                    }
+                                    Err(e) => {
+                                        error!(
+                                            "{} Re-login after waiting for app update failed: {}",
+                                            self.region.as_str().to_uppercase(),
+                                            e
+                                        );
+                                        return Err(AppError::UpgradeRequired);
+                                    }
                                 }
                             }
-                        }
-                        Err(e) => {
-                            error!(
-                                "{} Re-login after version refresh failed: {}",
-                                self.region.as_str().to_uppercase(),
-                                e
-                            );
-                            return Err(AppError::UpgradeRequired);
+                            Err(e) => {
+                                error!(
+                                    "{} Re-login after version refresh failed: {}",
+                                    self.region.as_str().to_uppercase(),
+                                    e
+                                );
+                                return Err(AppError::UpgradeRequired);
+                            }
                         }
                     }
+                    drop(guard);
                     retry_count += 1;
                     tokio::time::sleep(Duration::from_secs(1)).await;
                 }
@@ -889,9 +897,10 @@ impl SekaiClient {
                 }
             }
         }
-        Err(AppError::NetworkError(
-            "Max retry attempts reached".to_string(),
-        ))
+        Err(AppError::Internal(format!(
+            "Game API call gave up after {} session recovery attempts",
+            max_retries
+        )))
     }
 
     #[tracing::instrument(skip(self, body, params), fields(region = ?self.region))]
@@ -902,8 +911,15 @@ impl SekaiClient {
         params: Option<&HashMap<String, String>>,
     ) -> Result<(JsonValue, u16), AppError> {
         let session = self.get_session().ok_or(AppError::NoClientAvailable)?;
-        self.drive_game_api(&session, "POST", path, Some(body), params, false)
-            .await
+        self.drive_game_api(
+            &session,
+            reqwest::Method::POST,
+            path,
+            Some(body),
+            params,
+            false,
+        )
+        .await
     }
 
     async fn get_cp_image(&self, relative_path: &str) -> Result<Vec<u8>, AppError> {

--- a/src/client/token_utils.rs
+++ b/src/client/token_utils.rs
@@ -5,8 +5,15 @@ use crate::error::AppError;
 
 #[derive(Deserialize)]
 struct JwtPayload {
-    #[serde(alias = "userId", alias = "user_id")]
-    user_id: Option<String>,
+    // userId appears as either a JSON string or a number depending on the
+    // token source, same as in account files (see null_or_number_to_string).
+    #[serde(
+        alias = "userId",
+        alias = "user_id",
+        default,
+        deserialize_with = "super::account::null_or_number_to_string"
+    )]
+    user_id: String,
 }
 
 #[derive(Deserialize)]
@@ -26,9 +33,10 @@ pub fn extract_user_id_from_jwt(token: &str) -> Result<String, AppError> {
         .map_err(|e| AppError::ParseError(format!("JWT base64 decode error: {}", e)))?;
     let payload: JwtPayload = sonic_rs::from_slice(&payload_bytes)
         .map_err(|e| AppError::ParseError(format!("JWT payload parse error: {}", e)))?;
-    payload
-        .user_id
-        .ok_or_else(|| AppError::ParseError("userId not found in JWT".to_string()))
+    if payload.user_id.is_empty() {
+        return Err(AppError::ParseError("userId not found in JWT".to_string()));
+    }
+    Ok(payload.user_id)
 }
 
 pub fn extract_user_id_from_nuverse_token(token: &str) -> Result<String, AppError> {
@@ -63,6 +71,15 @@ mod tests {
     #[test]
     fn test_extract_user_id_from_jwt() {
         let payload = r#"{"userId":"12345"}"#;
+        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
+        let jwt = format!("header.{}.signature", encoded);
+        let result = extract_user_id_from_jwt(&jwt);
+        assert_eq!(result.unwrap(), "12345");
+    }
+
+    #[test]
+    fn test_extract_numeric_user_id_from_jwt() {
+        let payload = r#"{"userId":12345}"#;
         let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
         let jwt = format!("header.{}.signature", encoded);
         let result = extract_user_id_from_jwt(&jwt);

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,9 +50,11 @@ impl std::str::FromStr for ServerRegion {
 pub struct RedisConfig {
     #[serde(default)]
     pub enabled: bool,
-    #[serde(default)]
+    // Field-level defaults must match `impl Default`: a *partial* `redis:`
+    // section takes these, while a fully absent section takes the Default impl.
+    #[serde(default = "default_redis_host")]
     pub host: String,
-    #[serde(default)]
+    #[serde(default = "default_redis_port")]
     pub port: u16,
     #[serde(default)]
     pub password: String,
@@ -64,28 +66,12 @@ pub struct BackendConfig {
     pub host: String,
     #[serde(default = "default_port")]
     pub port: u16,
-    #[serde(default)]
-    pub ssl: bool,
-    #[serde(default)]
-    pub ssl_cert: String,
-    #[serde(default)]
-    pub ssl_key: String,
+    /// Default log level for this crate's targets; the RUST_LOG env var, when
+    /// set, takes precedence.
     #[serde(default = "default_log_level")]
     pub log_level: String,
     #[serde(default)]
-    pub main_log_file: String,
-    #[serde(default)]
-    pub access_log: String,
-    #[serde(default)]
-    pub access_log_path: String,
-    #[serde(default)]
     pub sekai_user_jwt_signing_key: String,
-    #[serde(default)]
-    pub enable_trust_proxy: bool,
-    #[serde(default)]
-    pub trusted_proxies: Vec<String>,
-    #[serde(default)]
-    pub proxy_header: String,
 }
 
 fn default_host() -> String {
@@ -97,21 +83,39 @@ fn default_port() -> u16 {
 fn default_log_level() -> String {
     "info".to_string()
 }
+fn default_redis_host() -> String {
+    "localhost".to_string()
+}
+fn default_redis_port() -> u16 {
+    6379
+}
 
 fn default_nuverse_schema_bundle_path() -> String {
     "Data/structures/nuverse_schema_bundle.json".to_string()
 }
 
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct DatabaseConfig {
     #[serde(default)]
     pub enabled: bool,
     #[serde(default)]
-    pub driver: String,
-    #[serde(default)]
     pub dsn: String,
-    #[serde(default)]
+    #[serde(default = "default_max_connections")]
     pub max_connections: u32,
+}
+
+fn default_max_connections() -> u32 {
+    10
+}
+
+impl Default for DatabaseConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            dsn: String::new(),
+            max_connections: default_max_connections(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -67,13 +67,30 @@ pub async fn init_master_db(config: &DatabaseConfig) -> Result<DatabaseConnectio
     Ok(db)
 }
 
+/// Percent-encode a URL userinfo component so passwords containing URL-special
+/// characters (@ / # : etc.) do not corrupt the redis:// connection URL.
+fn percent_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{:02X}", b)),
+        }
+    }
+    out
+}
+
 pub async fn init_redis(config: &RedisConfig) -> Result<redis::aio::ConnectionManager, AppError> {
     let url = if config.password.is_empty() {
         format!("redis://{}:{}", config.host, config.port)
     } else {
         format!(
             "redis://:{}@{}:{}",
-            config.password, config.host, config.port
+            percent_encode(&config.password),
+            config.host,
+            config.port
         )
     };
     let client = redis::Client::open(url)

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error)]
 pub enum AppError {
     #[error("Session expired")]
     SessionError,
@@ -75,7 +75,12 @@ impl AppError {
             AppError::UpgradeRequired => StatusCode::UPGRADE_REQUIRED,
             AppError::UnderMaintenance => StatusCode::SERVICE_UNAVAILABLE,
             AppError::InvalidServerRegion(_) | AppError::ParseError(_) => StatusCode::BAD_REQUEST,
-            AppError::UpstreamData(_) => StatusCode::BAD_GATEWAY,
+            // Upstream-fault classes: the game server (or the path to it) broke,
+            // not this service — surface as 502 so callers don't misattribute.
+            AppError::UpstreamData(_)
+            | AppError::NetworkError(_)
+            | AppError::InvalidHttpStatus(_)
+            | AppError::Unknown { .. } => StatusCode::BAD_GATEWAY,
             AppError::AuthError(_) => StatusCode::UNAUTHORIZED,
             AppError::NotFound(_) => StatusCode::NOT_FOUND,
             AppError::Forbidden(_) => StatusCode::FORBIDDEN,

--- a/src/error.rs
+++ b/src/error.rs
@@ -107,10 +107,16 @@ impl IntoResponse for AppError {
             status: status.as_u16(),
             message: self.to_string(),
         };
-        let json = sonic_rs::to_string(&body).unwrap_or_else(|_| {
-            r#"{"result":"failed","status":500,"message":"Internal error"}"#.to_string()
-        });
-        (status, [("content-type", "application/json")], json).into_response()
+        match sonic_rs::to_string(&body) {
+            Ok(json) => (status, [("content-type", "application/json")], json).into_response(),
+            // Keep the HTTP status consistent with the fallback body's status.
+            Err(_) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [("content-type", "application/json")],
+                r#"{"result":"failed","status":500,"message":"Internal error"}"#.to_string(),
+            )
+                .into_response(),
+        }
     }
 }
 

--- a/src/ingest_engine.rs
+++ b/src/ingest_engine.rs
@@ -125,9 +125,10 @@ impl IngestionEngine {
             .await;
 
         if !failed_tables.is_empty() {
-            // Surface the failure so the caller (master updater) does NOT advance
-            // the saved version on a partial ingest, which would otherwise leave
-            // the DB silently out of sync with the recorded version.
+            // Surface the failure to the caller. The master updater treats ingest
+            // as best-effort (files on disk and the git mirror track the download,
+            // not DB health) but records the failure and retries the ingest on its
+            // next cron tick; the CLI reports it per region.
             anyhow::bail!(
                 "ingestion failed for {} file(s): {:?}",
                 failed_tables.len(),
@@ -139,7 +140,10 @@ impl IngestionEngine {
     }
 
     async fn ingest_file(&self, path: &Path, region: &str) -> Result<()> {
-        let file_stem = path.file_stem().unwrap().to_str().unwrap();
+        let Some(file_stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            warn!("Skipping {}: non-UTF-8 filename", path.display());
+            return Ok(());
+        };
         let table_name = match self.resolve_table_name(file_stem) {
             Some(t) => t,
             None => return Ok(()),

--- a/src/ingest_engine.rs
+++ b/src/ingest_engine.rs
@@ -141,7 +141,11 @@ impl IngestionEngine {
 
     async fn ingest_file(&self, path: &Path, region: &str) -> Result<()> {
         let Some(file_stem) = path.file_stem().and_then(|s| s.to_str()) else {
-            warn!("Skipping {}: non-UTF-8 filename", path.display());
+            warn!(
+                "{} Skipping {}: non-UTF-8 filename",
+                region.to_uppercase(),
+                path.display()
+            );
             return Ok(());
         };
         let table_name = match self.resolve_table_name(file_stem) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,12 @@ use sea_orm::DatabaseConnection;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-/// A shared in-flight upstream call: holds the (status, serialized-json) result
-/// once the leader resolves it; followers await and clone the Arc<str> cheaply.
-pub type CoalescedCell = Arc<tokio::sync::OnceCell<(u16, Arc<str>)>>;
+/// A shared in-flight upstream call: holds the leader's outcome — success or
+/// error — once it resolves; followers await and clone it cheaply. Errors are
+/// stored too so a burst attached to a failing upstream produces exactly one
+/// upstream attempt, not one per follower.
+pub type CoalescedCell =
+    Arc<tokio::sync::OnceCell<Result<(u16, Arc<str>), crate::error::AppError>>>;
 
 /// In-process single-flight for read-endpoint responses. Concurrent requests for
 /// the same cache key share one in-flight upstream call (and its result) instead
@@ -48,9 +51,10 @@ impl Drop for InflightGuard<'_> {
 
 impl RequestCoalescer {
     /// Run `fetch` under single-flight for `key`: concurrent callers with the same
-    /// key share one in-flight execution and clone its result. Returns
-    /// `(result, was_leader)` — the leader is the caller that actually ran `fetch`
-    /// (and is responsible for any post-fetch work such as caching).
+    /// key share one in-flight execution and clone its outcome — including a
+    /// failure, so a struggling upstream sees one attempt per window rather than
+    /// one retry per queued follower. Returns `(result, was_leader)` — the leader
+    /// is the caller that actually ran `fetch`.
     pub async fn coalesce<F, Fut>(
         &self,
         key: &str,
@@ -79,7 +83,7 @@ impl RequestCoalescer {
             key,
             cell: cell.clone(),
         });
-        let outcome = cell.get_or_try_init(fetch).await.cloned();
+        let outcome = cell.get_or_init(|| async { fetch().await }).await.clone();
         (outcome, is_leader)
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -21,8 +21,12 @@ const COLOR_BRIGHT_MAGENTA: &str = "\x1b[95m";
 const COLOR_BRIGHT_CYAN: &str = "\x1b[96m";
 const COLOR_RESET: &str = "\x1b[0m";
 
-pub fn init() {
+/// Initialize logging. `default_level` (from backend.log_level) sets this
+/// crate's level when RUST_LOG is not set; RUST_LOG always takes precedence.
+pub fn init(default_level: &str) {
+    let default_directives = format!("haruki_sekai_api={},warn", default_level);
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .or_else(|_| tracing_subscriber::EnvFilter::try_new(&default_directives))
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("haruki_sekai_api=info,warn"));
     let _ = tracing_subscriber::fmt()
         .event_format(ColoredFormatter)

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,20 +18,22 @@ mod logging;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    logging::init();
+    // Config is loaded before logging init so backend.log_level can seed the
+    // default filter (RUST_LOG still wins); config errors go to stderr directly.
+    let config = match Config::load() {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            eprintln!("Failed to load config: {}", e);
+            std::process::exit(1);
+        }
+    };
+    logging::init(&config.backend.log_level);
 
     info!(
         "========================= Haruki Sekai API v{} =========================",
         env!("CARGO_PKG_VERSION")
     );
     info!("Powered by Haruki Dev Team");
-    let config = match Config::load() {
-        Ok(cfg) => cfg,
-        Err(e) => {
-            error!("Failed to load config: {}", e);
-            std::process::exit(1);
-        }
-    };
     let state = match init_app_state(config).await {
         Ok(s) => Arc::new(s),
         Err(e) => {

--- a/src/updater/apphash.rs
+++ b/src/updater/apphash.rs
@@ -66,7 +66,9 @@ impl AppHashUpdater {
                             "{} Found new app version: {} (hash: {})",
                             self.region.as_str().to_uppercase(),
                             new_info.app_version,
-                            &new_info.app_hash[..new_info.app_hash.len().min(16)]
+                            // chars(), not byte slicing: the hash is
+                            // network-supplied and panic = "abort" in release.
+                            new_info.app_hash.chars().take(16).collect::<String>()
                         );
 
                         if let Err(e) = self.update_version(&new_info).await {

--- a/src/updater/git.rs
+++ b/src/updater/git.rs
@@ -71,6 +71,22 @@ impl GitHelper {
         command
     }
 
+    /// Strip the configured password (raw and percent-encoded, as it appears in
+    /// credential-injected URLs) from text that may end up in errors/logs — git's
+    /// stderr for "unable to access" failures echoes the full remote URL
+    /// including userinfo.
+    fn redact(&self, text: &str) -> String {
+        if self.password.is_empty() {
+            return text.to_string();
+        }
+        let mut out = text.replace(&self.password, "***");
+        let encoded = pct_encode(&self.password);
+        if encoded != self.password {
+            out = out.replace(&encoded, "***");
+        }
+        out
+    }
+
     fn run(&self, mut command: Command, action: &str) -> Result<Output, AppError> {
         let output = command
             .output()
@@ -82,7 +98,7 @@ impl GitHelper {
             let detail = if detail.is_empty() {
                 output.status.to_string()
             } else {
-                detail.to_string()
+                self.redact(detail)
             };
             return Err(AppError::NetworkError(format!(
                 "git {} failed: {}",

--- a/src/updater/master.rs
+++ b/src/updater/master.rs
@@ -37,6 +37,10 @@ pub struct MasterUpdater {
     /// so their read-modify-writes do not clobber each other's fields.
     version_lock: Arc<tokio::sync::Mutex<()>>,
     db: Option<sea_orm::DatabaseConnection>,
+    /// Set when the last DB ingest failed. The next cron tick retries the ingest
+    /// even if the master version is unchanged, so a transient DB failure does not
+    /// leave the DB out of sync until the next upstream version bump.
+    ingest_failed: std::sync::atomic::AtomicBool,
 }
 
 impl MasterUpdater {
@@ -68,6 +72,7 @@ impl MasterUpdater {
             update_lock: tokio::sync::Mutex::new(()),
             version_lock,
             db,
+            ingest_failed: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -154,8 +159,20 @@ impl MasterUpdater {
             self.call_all_asset_updaters(&login_response.asset_version, &login_response.asset_hash)
                 .await;
         }
-        if need_master_update {
-            if self.region.is_cp_server() {
+        let retry_ingest = !need_master_update
+            && self
+                .ingest_failed
+                .load(std::sync::atomic::Ordering::Relaxed);
+        if retry_ingest {
+            warn!(
+                "{} Previous DB ingest failed; re-running master update for the current version...",
+                self.region.as_str().to_uppercase()
+            );
+        }
+        if need_master_update || retry_ingest {
+            if !need_master_update {
+                // retry path: version unchanged, just re-download + re-ingest
+            } else if self.region.is_cp_server() {
                 info!(
                     "{} New master data version: {}",
                     self.region.as_str().to_uppercase(),
@@ -186,15 +203,20 @@ impl MasterUpdater {
                 asset_hash: login_response.asset_hash.clone(),
                 cdn_version: login_response.cdn_version,
             };
-            if let Err(e) = self.save_version(&new_version).await {
-                error!(
-                    "{} Failed to save version file: {}",
-                    self.region.as_str().to_uppercase(),
-                    e
-                );
-                return;
-            }
-            self.client.version_helper.update(new_version);
+            // save_version returns the merged on-disk state so a concurrent
+            // app-hash update that landed mid-download is preserved in memory too.
+            let merged_version = match self.save_version(&new_version).await {
+                Ok(v) => v,
+                Err(e) => {
+                    error!(
+                        "{} Failed to save version file: {}",
+                        self.region.as_str().to_uppercase(),
+                        e
+                    );
+                    return;
+                }
+            };
+            self.client.version_helper.update(merged_version);
             if let Some(ref git_helper) = self.git_helper {
                 // git shells out via std::process and the push is a network call;
                 // run it on a blocking thread so it never stalls a tokio worker.
@@ -225,10 +247,27 @@ impl MasterUpdater {
         login: &crate::client::LoginResponse,
         current: &VersionInfo,
     ) -> (bool, bool) {
-        let need_master =
-            compare_version(&login.data_version, &current.data_version).unwrap_or(false);
-        let need_asset =
-            compare_version(&login.asset_version, &current.asset_version).unwrap_or(false);
+        // A version string that fails to parse must not silently freeze updates
+        // forever: log it, and treat "different and unparseable" as an update.
+        let compare_or_differ = |what: &str, new: &str, cur: &str| -> bool {
+            match compare_version(new, cur) {
+                Ok(newer) => newer,
+                Err(e) => {
+                    warn!(
+                        "{} Failed to compare {} versions ({:?} vs {:?}): {}; \
+treating difference as an update",
+                        self.region.as_str().to_uppercase(),
+                        what,
+                        new,
+                        cur,
+                        e
+                    );
+                    new != cur
+                }
+            }
+        };
+        let need_master = compare_or_differ("data", &login.data_version, &current.data_version);
+        let need_asset = compare_or_differ("asset", &login.asset_version, &current.asset_version);
 
         (need_master, need_asset)
     }
@@ -349,6 +388,7 @@ impl MasterUpdater {
         let master_dir = &self.client.config.master_dir;
         tokio::fs::create_dir_all(master_dir).await?;
 
+        let mut written_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
         if self.region.is_cp_server() {
             let paths: Vec<String> = login
                 .suite_master_split_path
@@ -364,6 +404,7 @@ impl MasterUpdater {
             for api_path in paths {
                 let data = self.download_cp_master_split(session, &api_path).await?;
                 self.save_master_files(&data, master_dir).await?;
+                written_keys.extend(data.keys().cloned());
             }
         } else {
             let url = format!(
@@ -372,7 +413,10 @@ impl MasterUpdater {
             );
             let restored = self.download_nuverse_master(&url).await?;
             self.save_master_files(&restored, master_dir).await?;
+            written_keys.extend(restored.keys().cloned());
         }
+        self.remove_stale_master_files(master_dir, &written_keys)
+            .await;
 
         // Ingest into the DB synchronously (awaited so failures are visible and
         // engine-init errors are caught; CPU parsing is offloaded via
@@ -388,26 +432,38 @@ impl MasterUpdater {
                 "{} Starting database ingestion for new master data...",
                 region_upper
             );
-            match crate::ingest_engine::IngestionEngine::new(db).await {
+            let ingest_ok = match crate::ingest_engine::IngestionEngine::new(db).await {
                 Ok(engine) => {
                     let region_str = self.region.as_str().to_lowercase();
                     match engine.ingest_master_data(master_dir, &region_str).await {
-                        Ok(()) => info!(
-                            "{} Master Data successfully ingested into database",
-                            region_upper
-                        ),
-                        Err(e) => error!(
-                            "{} Master Data DB ingestion failed (files saved; git mirror and \
-version unaffected): {e:#}",
-                            region_upper
-                        ),
+                        Ok(()) => {
+                            info!(
+                                "{} Master Data successfully ingested into database",
+                                region_upper
+                            );
+                            true
+                        }
+                        Err(e) => {
+                            error!(
+                                "{} Master Data DB ingestion failed (files saved; git mirror and \
+version unaffected; will retry on the next cron tick): {e:#}",
+                                region_upper
+                            );
+                            false
+                        }
                     }
                 }
-                Err(e) => error!(
-                    "{} Failed to initialize ingestion engine (skipping DB ingest): {e:#}",
-                    region_upper
-                ),
-            }
+                Err(e) => {
+                    error!(
+                        "{} Failed to initialize ingestion engine (skipping DB ingest; will \
+retry on the next cron tick): {e:#}",
+                        region_upper
+                    );
+                    false
+                }
+            };
+            self.ingest_failed
+                .store(!ingest_ok, std::sync::atomic::Ordering::Relaxed);
         }
 
         info!(
@@ -415,6 +471,58 @@ version unaffected): {e:#}",
             self.region.as_str().to_uppercase()
         );
         Ok(())
+    }
+
+    /// Remove top-level `{key}.json` files whose key vanished from the newly
+    /// downloaded master set, so tables deleted upstream do not survive locally
+    /// (and keep getting re-ingested) forever. Conservative: only touches
+    /// identifier-like stems — version snapshots (`4.3.1.20.json`) and other
+    /// dotted names are left alone — and never the configured version file.
+    async fn remove_stale_master_files(
+        &self,
+        master_dir: &str,
+        written_keys: &std::collections::HashSet<String>,
+    ) {
+        if written_keys.is_empty() {
+            return;
+        }
+        let version_canon = std::fs::canonicalize(&self.client.config.version_path).ok();
+        let mut rd = match tokio::fs::read_dir(master_dir).await {
+            Ok(rd) => rd,
+            Err(_) => return,
+        };
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            let p = entry.path();
+            if p.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let Some(stem) = p.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let identifier_like = stem.chars().next().is_some_and(|c| c.is_ascii_alphabetic())
+                && stem.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
+            if !identifier_like || written_keys.contains(stem) {
+                continue;
+            }
+            if let (Some(vc), Ok(pc)) = (&version_canon, std::fs::canonicalize(&p)) {
+                if *vc == pc {
+                    continue;
+                }
+            }
+            match tokio::fs::remove_file(&p).await {
+                Ok(()) => info!(
+                    "{} Removed stale master file {}",
+                    self.region.as_str().to_uppercase(),
+                    p.display()
+                ),
+                Err(e) => warn!(
+                    "{} Failed to remove stale master file {}: {}",
+                    self.region.as_str().to_uppercase(),
+                    p.display(),
+                    e
+                ),
+            }
+        }
     }
 
     /// Download and restore the Nuverse master blob with a bounded retry, mirroring
@@ -566,6 +674,15 @@ version unaffected): {e:#}",
         let mut success_count = 0;
         let mut fail_count = 0;
         for (key, value) in data {
+            if !is_safe_path_component(key) {
+                warn!(
+                    "{} Skipping master key {:?}: not a safe filename",
+                    self.region.as_str().to_uppercase(),
+                    key
+                );
+                fail_count += 1;
+                continue;
+            }
             let file_path = Path::new(master_dir).join(format!("{}.json", key));
             let json = match sonic_rs::to_string_pretty(value) {
                 Ok(j) => j,
@@ -600,15 +717,27 @@ version unaffected): {e:#}",
             total_keys,
             fail_count
         );
-        if fail_count > 0 && success_count == 0 {
-            return Err(crate::error::AppError::ParseError(
-                "All master file writes failed".to_string(),
-            ));
+        if fail_count > 0 {
+            // A torn write set must not be recorded as a completed update: bail so
+            // the caller neither saves the version nor pushes the git mirror, and
+            // the next cron tick re-downloads.
+            return Err(crate::error::AppError::IoError(format!(
+                "{} of {} master file writes failed",
+                fail_count, total_keys
+            )));
         }
         Ok(())
     }
 
-    async fn save_version(&self, version: &VersionInfo) -> Result<(), crate::error::AppError> {
+    /// Persist the master/asset version fields, preserving whatever
+    /// `appVersion`/`appHash` are currently on disk: those belong to the
+    /// AppHashUpdater, and our in-memory copy may be minutes stale (snapshotted
+    /// before a long download), so overwriting them here would revert a
+    /// concurrent app-hash update. Returns the merged state as written.
+    async fn save_version(
+        &self,
+        version: &VersionInfo,
+    ) -> Result<VersionInfo, crate::error::AppError> {
         let path = &self.client.config.version_path;
         // Serialize with the AppHashUpdater so neither clobbers the other's fields.
         let _guard = self.version_lock.lock().await;
@@ -618,14 +747,12 @@ version unaffected): {e:#}",
         } else {
             serde_json::Map::new()
         };
-        existing.insert(
-            "appVersion".to_string(),
-            serde_json::Value::String(version.app_version.clone()),
-        );
-        existing.insert(
-            "appHash".to_string(),
-            serde_json::Value::String(version.app_hash.clone()),
-        );
+        existing
+            .entry("appVersion".to_string())
+            .or_insert_with(|| serde_json::Value::String(version.app_version.clone()));
+        existing
+            .entry("appHash".to_string())
+            .or_insert_with(|| serde_json::Value::String(version.app_hash.clone()));
         existing.insert(
             "dataVersion".to_string(),
             serde_json::Value::String(version.data_version.clone()),
@@ -645,9 +772,44 @@ version unaffected): {e:#}",
         let json = sonic_rs::to_string_pretty(&existing)
             .map_err(|e| crate::error::AppError::ParseError(e.to_string()))?;
         crate::client::helper::write_file_atomic(Path::new(path), json.as_bytes()).await?;
-        let dir = Path::new(path).parent().unwrap_or(Path::new("."));
-        let versioned_path = dir.join(format!("{}.json", version.data_version));
-        crate::client::helper::write_file_atomic(&versioned_path, json.as_bytes()).await?;
-        Ok(())
+        // The versioned snapshot filename embeds a server-supplied string; refuse
+        // anything that could escape the version directory.
+        if is_safe_path_component(&version.data_version) {
+            let dir = Path::new(path).parent().unwrap_or(Path::new("."));
+            let versioned_path = dir.join(format!("{}.json", version.data_version));
+            crate::client::helper::write_file_atomic(&versioned_path, json.as_bytes()).await?;
+        } else {
+            warn!(
+                "{} Skipping versioned snapshot: dataVersion {:?} is not a safe filename",
+                self.region.as_str().to_uppercase(),
+                version.data_version
+            );
+        }
+        let str_field = |key: &str, fallback: &str| -> String {
+            existing
+                .get(key)
+                .and_then(|v| v.as_str())
+                .unwrap_or(fallback)
+                .to_string()
+        };
+        Ok(VersionInfo {
+            app_version: str_field("appVersion", &version.app_version),
+            app_hash: str_field("appHash", &version.app_hash),
+            data_version: version.data_version.clone(),
+            asset_version: version.asset_version.clone(),
+            asset_hash: version.asset_hash.clone(),
+            cdn_version: version.cdn_version,
+        })
     }
+}
+
+/// True if `s` can be safely embedded in a filename within the intended
+/// directory: non-empty, no path separators, and not a dot-relative component.
+fn is_safe_path_component(s: &str) -> bool {
+    !s.is_empty()
+        && s != "."
+        && s != ".."
+        && !s.contains('/')
+        && !s.contains('\\')
+        && !s.contains('\0')
 }

--- a/src/updater/master.rs
+++ b/src/updater/master.rs
@@ -416,7 +416,7 @@ treating difference as an update",
             written_keys.extend(restored.keys().cloned());
         }
         self.remove_stale_master_files(master_dir, &written_keys)
-            .await;
+            .await?;
 
         // Ingest into the DB synchronously (awaited so failures are visible and
         // engine-init errors are caught; CPU parsing is offloaded via
@@ -478,20 +478,20 @@ retry on the next cron tick): {e:#}",
     /// (and keep getting re-ingested) forever. Conservative: only touches
     /// identifier-like stems — version snapshots (`4.3.1.20.json`) and other
     /// dotted names are left alone — and never the configured version file.
+    /// Failures propagate so a stale table cannot silently survive: the caller
+    /// aborts the update, the version is not saved, and the next cron tick
+    /// retries the whole download-and-clean cycle.
     async fn remove_stale_master_files(
         &self,
         master_dir: &str,
         written_keys: &std::collections::HashSet<String>,
-    ) {
+    ) -> Result<(), crate::error::AppError> {
         if written_keys.is_empty() {
-            return;
+            return Ok(());
         }
         let version_canon = std::fs::canonicalize(&self.client.config.version_path).ok();
-        let mut rd = match tokio::fs::read_dir(master_dir).await {
-            Ok(rd) => rd,
-            Err(_) => return,
-        };
-        while let Ok(Some(entry)) = rd.next_entry().await {
+        let mut rd = tokio::fs::read_dir(master_dir).await?;
+        while let Some(entry) = rd.next_entry().await? {
             let p = entry.path();
             if p.extension().and_then(|e| e.to_str()) != Some("json") {
                 continue;
@@ -509,20 +509,20 @@ retry on the next cron tick): {e:#}",
                     continue;
                 }
             }
-            match tokio::fs::remove_file(&p).await {
-                Ok(()) => info!(
-                    "{} Removed stale master file {}",
-                    self.region.as_str().to_uppercase(),
-                    p.display()
-                ),
-                Err(e) => warn!(
-                    "{} Failed to remove stale master file {}: {}",
-                    self.region.as_str().to_uppercase(),
+            tokio::fs::remove_file(&p).await.map_err(|e| {
+                crate::error::AppError::IoError(format!(
+                    "Failed to remove stale master file {}: {}",
                     p.display(),
                     e
-                ),
-            }
+                ))
+            })?;
+            info!(
+                "{} Removed stale master file {}",
+                self.region.as_str().to_uppercase(),
+                p.display()
+            );
         }
+        Ok(())
     }
 
     /// Download and restore the Nuverse master blob with a bounded retry, mirroring
@@ -697,7 +697,7 @@ retry on the next cron tick): {e:#}",
                     continue;
                 }
             };
-            match tokio::fs::write(&file_path, json).await {
+            match crate::client::helper::write_file_atomic(&file_path, json.as_bytes()).await {
                 Ok(_) => success_count += 1,
                 Err(e) => {
                     warn!(


### PR DESCRIPTION
## Summary

Fix batch from a deep review of the whole codebase (excluding generated models). Includes the pending coalescer cleanup commit (bb4ec7c) this work builds on.

### ⚠️ Behavior changes to note before deploying

- **`/image/{server}/mysekai/{p1}/{p2}` now requires the `x-haruki-sekai-token` JWT.** Its Nuverse branch accepted guessable numeric params and drove authenticated game API calls with the shared bot account anonymously. HarukiBot must send the token on this route.
- **`run_ingest` now reads `master_dir` directly** (matching the updater) instead of `{master_dir}/master`. Verify the production layout.
- Auth cache TTL is now 300s (was 12h), so revoking a user/server grant takes effect within 5 minutes.

### SekaiClient
- Network-layer retries only for idempotent GETs — a timed-out POST may already have executed server-side, and retrying risked double-executing game actions.
- 426 (upgrade) and cookie-expired recovery paths are now single-flighted like SessionError, instead of thundering-herd relogins.
- `call_api` takes `reqwest::Method` (no silent fallback of unknown strings to GET); body packed once per call; `init()` reuses `reload_accounts()` (concurrent logins on startup); token log previews truncate on char boundaries.

### API layer
- Coalesced fetch errors are stored and shared with followers (one upstream attempt per window instead of one retry per queued follower); the response cache is populated inside the in-flight window, closing the stampede gap and caching any successful fetch.
- Upstream-fault errors (`NetworkError`, `InvalidHttpStatus`, `Unknown`) map to 502 instead of 500; image fetches propagate upstream 404.

### Updater
- `save_version` no longer reverts a concurrent app-hash update with a stale pre-download snapshot, and returns the merged on-disk state for the in-memory copy.
- `save_master_files` fails on any write failure instead of recording a torn file set as a completed version; master files whose keys vanished upstream are cleaned up; failed DB ingests retry on the next cron tick instead of waiting for the next upstream version bump.
- Unparseable version strings log and fall back to "different ⇒ update" instead of silently freezing updates; server-supplied path components are sanitized; git push errors redact credentials; app-hash log preview can no longer panic (fatal under `panic = "abort"`).

### Client / config
- All `Set-Cookie` headers are collected with attributes stripped; empty/unparseable cookies are failures, not cached successes. CP JWT `userId` parses as string or number.
- Dead config fields removed (`ssl*`, `main_log_file`, `access_log*`, trust-proxy fields, `database.driver` — none were ever read; `ssl: true` silently served plain HTTP). `backend.log_level` is now actually wired (RUST_LOG wins). `max_connections` defaults to 10 instead of a 1-connection pool. Partial `redis:` sections get the documented localhost defaults; the redis password is percent-encoded.
- Nuverse restore path consumes values instead of deep-cloning every leaf, with a precomputed key→field index preserving the previous output ordering.

## Test plan

- `cargo test` — 28 pass (2 new: numeric JWT userId, image-prefix server extraction)
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vq3cfG4QcGos75AQARBD2c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mysekai image endpoints now require authentication.
  * Master-data ingestion retries failures on the next cycle (skips non-UTF8 files).
  * JWT user identifiers now accept numeric forms.

* **Bug Fixes**
  * Image/auth/API errors now return consistent JSON with correct HTTP statuses (e.g., proper 404 handling).
  * Cached request coalescing now shares both successes and failures, and cleans up cancelled leaders.
  * Cookie refresh and session recovery are safer under concurrency.
  * Redis/auth and startup behavior are more robust (including safer Redis URL handling).
  * Master-data updates are safer and more resilient to parse/file issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->